### PR TITLE
First attempt at TIRv2.

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -16,6 +16,34 @@ pub type CrateHash = u64;
 pub type DefIndex = u32;
 pub type BasicBlockIndex = u32;
 pub type LocalIndex = u32;
+pub type TyIndex = u32;
+pub type FieldIndex = u32;
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+pub struct Local {
+    idx: LocalIndex,
+    ty: TyIndex,
+}
+
+impl Local {
+    pub fn new(idx: LocalIndex, ty: TyIndex) -> Self {
+        Self { idx, ty }
+    }
+
+    pub fn idx(&self) -> LocalIndex {
+        self.idx
+    }
+
+    pub fn ty(&self) -> TyIndex {
+        self.ty
+    }
+}
+
+impl Display for Local {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "${}: t{}", self.idx, self.ty)
+    }
+}
 
 /// A mirror of the compiler's notion of a "definition ID".
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -62,9 +90,12 @@ impl Display for Tir {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "[Begin TIR for {}]", self.item_path_str)?;
         writeln!(f, "    {}:", self.def_id)?;
+        let mut block_strs = Vec::new();
         for (i, b) in self.blocks.iter().enumerate() {
-            write!(f, "    bb{}:\n{}", i, b)?;
+            block_strs.push(format!("    bb{}:\n{}", i, b));
         }
+        println!("{:?}", block_strs);
+        writeln!(f, "{}", block_strs.join("\n"))?;
         writeln!(f, "[End TIR for {}]", self.item_path_str)?;
         Ok(())
     }
@@ -85,21 +116,76 @@ impl BasicBlock {
 impl Display for BasicBlock {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for s in self.stmts.iter() {
-            write!(f, "        {}", s)?;
+            write!(f, "        {}\n", s)?;
         }
-        writeln!(f, "        term: {}\n", self.term)
+        write!(f, "        {}", self.term)
     }
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum Statement {
+    /// Do nothing.
     Nop,
+    /// An assignment to a local variable.
+    Assign(Local, Rvalue),
+    /// Store into the memory.
+    Store(Local, Operand),
+    /// Any unimplemented lowering maps to this variant.
     Unimplemented,
 }
 
 impl Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "{:?}", self)
+        match self {
+            Statement::Nop => write!(f, "nop"),
+            Statement::Assign(l, r) => write!(f, "{} = {}", l, r),
+            Statement::Store(ptr, val) => write!(f, "store({}, {})", ptr, val),
+            _ => write!(f, "unimplemented"),
+        }
+    }
+}
+
+/// The right-hand side of an assignment.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum Rvalue {
+    /// Another local variable.
+    Operand(Operand),
+    /// Get a pointer to a field.
+    GetField(Local, FieldIndex),
+    /// Load a value of specified type from a pointer.
+    Load(Local),
+    /// Binary Ops.
+    Add(Operand, Operand),
+    Sub(Operand, Operand),
+    /// Allocate space for the specified type on the stack and return a pointer to it.
+    Alloca(TyIndex),
+}
+
+impl Display for Rvalue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Rvalue::Operand(o) => write!(f, "{}", o),
+            Rvalue::GetField(ptr, fidx) => write!(f, "get_field({}, {})", ptr, fidx),
+            Rvalue::Load(l) => write!(f, "load({})", l),
+            Rvalue::Add(l, r) => write!(f, "int_add({}, {})", l, r),
+            Rvalue::Sub(l, r) => write!(f, "int_sub({}, {})", l, r),
+            Rvalue::Alloca(t) => write!(f, "alloca({})", t),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum Operand {
+    Local(Local),
+    Constant(Constant),
+}
+
+impl Display for Operand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Operand::Local(l) => write!(f, "{}", l),
+            Operand::Constant(c) => write!(f, "{}", c),
+        }
     }
 }
 
@@ -110,6 +196,16 @@ pub enum Constant {
     Unimplemented,
 }
 
+impl Display for Constant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Constant::UnsignedInt(u) => write!(f, "{}", u),
+            Constant::SignedInt(s) => write!(f, "{}", s),
+            Constant::Unimplemented => write!(f, "Unimplemented Constant"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum UnsignedInt {
     Usize(usize),
@@ -118,7 +214,12 @@ pub enum UnsignedInt {
     U32(u32),
     U64(u64),
     U128 { hi: u64, lo: u64 },
-    Unimplemented,
+}
+
+impl Display for UnsignedInt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl UnsignedInt {
@@ -146,7 +247,12 @@ pub enum SignedInt {
     I32(i32),
     I64(i64),
     I128 { hi: u64, lo: u64 },
-    Unimplemented,
+}
+
+impl Display for SignedInt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl SignedInt {


### PR DESCRIPTION
Hi,

Here are our first baby steps with "TIR v2".

To demonstrate how it might work, consider the Rust code:
```
struct Point {
    x: u32,
    y: u32,
}
...
let mut p = Point {x: 25, y: 50};
p.y += 100;
```

I can imagine this lowering to (supposing this is a textual representation of the in-memory structs):
```
$1 = Alloca(64);
$2 = AddressOf(LocalIndex);
MemStore($2, 0, 25u32, 4);
MemStore($2, 4, 50u32, 4);
$3 = MemLoad($2, 4, 4);
$4 = AddU32($3, 100u32);
MemStore($2, 4, $4, 4);
```

There are lots of design decisions to take into account here. Please comment on the following...

## Should we have Explicit Variable Types?

Initially I'd set out to have each TIR local variable typed, as PyPy does, e.g.:
```
%i0 = ...
%p0 = ...
```

However, I went off the idea because it's kind of irritating to carry around the type information with the variable. I'd considered thing like integer tagging and `(type, index)` pairs, but neither option feels right somehow. It's much easier if a variable is just a number.

The proposed TIR essentially contains *no* explicit type information. What do you think? Does the JIT runtime need the types of things to hand?

## Correctness

The proposed TIR is flexible, but the encoding allows for nonsensical programs. For example:
```
$0 = Alloca(1);
$1 = AddressOf($0);
MemStore($1, 0, 100u64, 2); // ptr, offset, val, num_bytes
```

This TIR would be wrong in two ways:
 * We try to write a 64-bit constant to a one-byte variable.
 * We passed a different byte-size (2) than both the constant we are storing and the size of the allocation.

Is that OK, or would be want a TIR which, by construction, can never be incorrect? Is it even possible? I suspect not...

## AddressOf

`AddressOf` seems necessary to make a pointer from a value (and I suppose me might need a deref later). What do you think?

## Typed Operations

One idea I toyed with was the idea of "typed operations", where you can always know the type of the thing on the left-hand side of an assignment from the operation on the right-hand side.

This would mean, for example, that instead of having a single load from memory operation:
```
MemLoad{ptr: Operand, offset: Operand, num_bytes: Operand},
```

We'd perhaps have many:
```
MemLoad_U8{ptr: Operand, offset: Operand},
MemLoad_U16{ptr: Operand, offset: Operand},
MemLoad_U32{ptr: Operand, offset: Operand},
...
```

This would make the set of operations much larger, but makes knowing the types of things at runtime a bit easier. Notice also that the `num_bytes` parameter disappears.

Assigning one variable from another becomes odd though, as there's no operation on the right-hand side that could imply the types. Perhaps we'd have to do something like:
```
$1 = IdU8($2);
```

(i.e. the ID function)

Perhaps one upside of typed operations is that we could encode user struct and enum types more easily, for example:

```
MemLoadADT{ptr: Operand, type: ADTIndex}
```

(ADT = abstract data type -- Rust's name for structs and enums)

Here we've added a `type` operand, which identifies the type of the struct we are loading. There could be a table elsewhere which keeps track of the sizes of each ADT, thus removing the need for a `num_bytes` operand for user structs.

Struct/enum allocas could similarly accept a `ADTIndex` instead of a byte size.

For comparison purposes, the Rust code in the beginning of the PR might lower to the following typed-operations TIR:

```
# Suppose `struct Point` is ADTIndex 33
$1 = AllocaADT(33);
$2 = AddressOfADT(LocalIndex, 33);
MemStoreU32($2, 0, 25u32);
MemStoreU32($2, 4, 50u32);
$3 = MemLoadU32($2, 4);
$4 = AddU32($3, 100u32);
MemStoreU32($2, 4, $4);
```

Here the stores feel clumsy, as there's no lvalue to associate type with.

## Summary

Hopefully it's evident that I'm really not sure what the right thing to do is. I'm keen to hear your ideas.

Thanks -- End of essay ;)