### PR TITLE
Implement enough stuctures to lower a comparison with a constant int.

### DIFF
--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -41,8 +41,8 @@ pub use types::*;
 #[cfg(test)]
 mod tests {
     use super::{
-        BasicBlock, Constant, Decoder, DefId, Encoder, Local, Operand, Pack, Rvalue, Statement,
-        Terminator, Tir, UnsignedInt,
+        BasicBlock, BinOp, Constant, ConstantInt, Decoder, DefId, Encoder, Local, Operand, Pack,
+        Rvalue, Statement, Terminator, Tir, UnsignedInt,
     };
     use fallible_iterator::{self, FallibleIterator};
     use std::io::{Cursor, Seek, SeekFrom};
@@ -124,16 +124,11 @@ mod tests {
     #[test]
     fn test_text_dump() {
         let stmts_t1_b0 = vec![
-            Statement::Assign(
-                Local::new(0, 0),
-                Rvalue::Operand(Operand::Local(Local::new(1, 0))),
-            ),
+            Statement::Assign(Local::new(0, 0), Rvalue::Local(Local::new(1, 0))),
             Statement::Assign(Local::new(2, 0), Rvalue::GetField(Local::new(3, 0), 4)),
             Statement::Assign(
                 Local::new(4, 0),
-                Rvalue::Operand(Operand::Constant(Constant::UnsignedInt(UnsignedInt::U8(
-                    10,
-                )))),
+                Rvalue::Constant(Constant::Int(ConstantInt::UnsignedInt(UnsignedInt::U8(10)))),
             ),
             Statement::Nop,
         ];
@@ -143,14 +138,16 @@ mod tests {
             Statement::Store(Local::new(5, 0), Operand::Local(Local::new(4, 0))),
             Statement::Assign(
                 Local::new(7, 0),
-                Rvalue::Add(
+                Rvalue::BinaryOp(
+                    BinOp::Add,
                     Operand::Local(Local::new(8, 0)),
                     Operand::Local(Local::new(9, 0)),
                 ),
             ),
             Statement::Assign(
                 Local::new(7, 0),
-                Rvalue::Sub(
+                Rvalue::BinaryOp(
+                    BinOp::Sub,
                     Operand::Local(Local::new(9, 0)),
                     Operand::Local(Local::new(10, 0)),
                 ),
@@ -170,7 +167,7 @@ mod tests {
                 DefId::new(3, 4),
                 String::from("item2"),
                 vec![BasicBlock::new(
-                    vec![Statement::Unimplemented],
+                    vec![Statement::Unimplemented(String::from("abc"))],
                     Terminator::Unreachable,
                 )],
             )),
@@ -193,15 +190,15 @@ mod tests {
     bb1:
         $5: t0 = load($6: t0)
         store($5: t0, $4: t0)
-        $7: t0 = int_add($8: t0, $9: t0)
-        $7: t0 = int_sub($9: t0, $10: t0)
+        $7: t0 = add($8: t0, $9: t0)
+        $7: t0 = sub($9: t0, $10: t0)
         $11: t0 = alloca(0)
         goto bb50
 [End TIR for item1]
 [Begin TIR for item2]
     DefId(3, 4):
     bb0:
-        unimplemented
+        unimplemented_stmt: abc
         unreachable
 [End TIR for item2]\n";
 


### PR DESCRIPTION
TLDR: Implement enough stuff to lower an instruction like:
```
$3: t0 = ge($2: t0, I32(2000))
```
In doing so, I've noticed a few oddities with our intial design which
I've also addressed:

 - It seems odd to have an Operand as a Rvalue. It makes more sense to
   lift Operand's constituent bits directly into the Rvalue enum. In
   doing so we can reduce the number of "this can't happen"s later. E.g.
   we know something can only accept a constant, but we'd have to use an
   Operand and consider the Local case too.

   Operand still remains for operations which can accept both a constant
   *or* a local.

 - Instead of having binary integer operations as top-level rvalues, group them
   under a BinaryOp enum. This will allow us to more easily treat binary
   ops uniformly based on structure.

   Nullary and Unary ops will follow at some point.

 - Similarly for constant integers. Group them into a ConstantInt enum.

 - TIR operations are polymorphic, so the Add operation should Display
   as "add", not "int_add".

Additionally, I've made the Display for an unimplemented statement
lowering include the stringified MIR of the statement, so I can easily
see what lowering need to be implemented next.

Companion compiler PR will come soon.