### PR TITLE
Add the binary symbol name to static call operands.

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -323,7 +323,9 @@ impl Display for SignedInt {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum CallOperand {
     /// A statically known function identified by its DefId.
-    Fn(DefId),
+    /// A pair: the definition ID and the binary symbol name, if known. If the callee doeesn't have
+    /// all of its type parameters instantiated, then there will be no symbol.
+    Fn(DefId, Option<String>),
     /// An unknown or unhandled callable.
     Unknown, // FIXME -- Find out what else. Closures jump to mind.
 }
@@ -331,7 +333,13 @@ pub enum CallOperand {
 impl Display for CallOperand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CallOperand::Fn(def_id) => write!(f, "{}", def_id),
+            CallOperand::Fn(def_id, sym_name) => {
+                let sym_name_str = match sym_name {
+                    Some(n) => n,
+                    None => "<unknown>",
+                };
+                write!(f, "def_id={}, sym_name={}", def_id, sym_name_str)
+            }
             CallOperand::Unknown => write!(f, "unknown"),
         }
     }


### PR DESCRIPTION
**TLDR: Having binary-level symbol names in TIR calls is going to be useful a bit later.**

Whilst thinking about how to implement a TIR interpreter, I realised that you really can't do much in Rust without function calls. For example, loops are usually function calls (due to iterators), and even returning a numeric exit status requires a non-convergent call.

If we have TIR for the callee, then we should follow the call and start interpreting there. But we know we won't always have TIR for every func. In these cases, we'd have to call the target natively.

As it stands, a TIR call operand is a DefId, but the problem with those is that one DefId can map to many monomorphised versions at the binary level. This is due to type parameterisation.

When we encounter a call when we are interpreting and we have no TIR for the target (or later in development, when we see a call in a compiled trace), we will need to know what external function address to invoke. We could try to  make our own mapping somehow, but I realised that Rust doesn't strip its binaries, meaning that every monomorphised function has a binary-level symbol:

```
$ nm target/release/nothing
...
0000000000014ce0 t _ZN7nothing4main17hc8190d84b5b1bb67E
00000000000a3fb0 t _ZN80_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$alloc..vec..SpecExtend$LT$T$C$I$GT$$GT$9from_iter17h7526e3b3e5fbf909E
00000000000a43b0 t _ZN80_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$alloc..vec..SpecExtend$LT$T$C$I$GT$$GT$9from_iter17h9e68ba58ac741f06E
00000000000bd650 t _ZN80_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..index..IndexMut$LT$I$GT$$GT$9index_mut17h09718c98445c3146E
00000000000a4e00 t _ZN80_$LT$alloc..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..index..IndexMut$LT$I$GT$$GT$9index_mut17ha718895e33b196c9E
00000000000ee470 T _ZN80_$LT$alloc..vec..Vec$LT$u8$GT$$u20$as$u20$core..convert..From$LT$$RF$str$GT$$GT$4from17hc952ca9ebe8ac127E
00000000000ad1b0 T _ZN80_$LT$std..error..ErrorIter$u20$as$u20$core..iter..traits..iterator..Iterator$GT$4next17h815625da29da01e5E
0000000000062750 T _ZN80_$LT$std..fs..OpenOptions$u20$as$u20$std..sys..unix..ext..fs..OpenOptionsExt$GT$12custom_flags17hc1b223a8e786f9d9E
00000000000626d0 T _ZN80_$LT$std..fs..OpenOptions$u20$as$u20$std..sys..unix..ext..fs..OpenOptionsExt$GT$4mode17hd242fea3f5793e9eE
0000000000062570 T _ZN80_$LT$std..fs..Permissions$u20$as$u20$std..sys..unix..ext..fs..PermissionsExt$GT$4mode17h038c4775b61713deE
00000000000625f0 T _ZN80_$LT$std..fs..Permissions$u20$as$u20$std..sys..unix..ext..fs..PermissionsExt$GT$8set_mode17h721768db973c88f3E
0000000000062660 T _ZN80_$LT$std..fs..Permissions$u20$as$u20$std..sys..unix..ext..fs..PermissionsExt$GT$9from_mode17h30bed70f0a505741E
...
```

You can above see my `main` function.

So this can serve as our mapping. To get the concrete address to call, we'd just have to relocate the function offsets shown above using dl_iterate_phdr(3). We could build such a mapping once at VM start time.

Then it's just a matter of using an x86 `CALL` instruction to resume execution at the relocated address with the argument registers loaded appropriately.

What do you think of the approach?

Here's a CFG with symbol names included. Having the symbol names present also serves as a debugging aid. Before I was guessing what the blue boxes are calls to:

![image](https://user-images.githubusercontent.com/604955/59217632-46d23200-8bb6-11e9-8390-48af9f654799.png)

In this example, most of the calls are to the software trace recorder. The only call which isn't to the recorder is where we exit with a specific numeric value.

(Compiler change to follow after discussion)