### PR TITLE
Tiri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members=[
     "ykpack",
     "ykrt",
-    "yktrace"
+    "yktrace",
+    "tiri",
 ]

--- a/tiri/Cargo.toml
+++ b/tiri/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tiri"
+version = "0.1.0"
+authors = ["Edd Barrett <vext01@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ykpack = { path = "../ykpack" }
+elf = "0.0"
+fallible-iterator = "0.2"

--- a/tiri/src/main.rs
+++ b/tiri/src/main.rs
@@ -1,0 +1,110 @@
+// Copyright 2019 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Tiri -- TIR interpreter.
+//!
+//! No effort has been made to make this fast.
+
+use elf;
+use fallible_iterator::FallibleIterator;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use ykpack::{BasicBlockIndex, Body, Decoder, DefId, Pack, Statement, StatementIndex, Terminator};
+
+/// The interpreter maintains a stack of these to keep track of calls.
+struct Frame<'p> {
+    /// A reference to the TIR body corresponding with this `Frame`.
+    body: &'p Body,
+    /// The current execution position in the above TIR body.
+    pc: (BasicBlockIndex, StatementIndex),
+}
+
+impl<'p> Frame<'p> {
+    /// Create a new frame and position its program counter at the beginning of the first block.
+    fn new(body: &'p Body) -> Self {
+        Self { body, pc: (0, 0) }
+    }
+}
+
+/// The interpreter itself.
+/// The struct itself holds only immutable program information.
+struct Interp {
+    /// Maps a `DefId` to the corresponding TIR body.
+    tir_map: HashMap<DefId, Body>,
+    /// The `DefId` of the `main()` function, which serves as the entry point.
+    main_defid: DefId,
+}
+
+impl Interp {
+    /// Create a new interpreter, using the TIR found in the `.yk_tir` section of the binary `bin`.
+    fn new(bin: &Path) -> Self {
+        let ef = elf::File::open_path(&PathBuf::from(bin)).unwrap();
+        let sec = ef.get_section(".yk_tir").unwrap();
+        let mut curs = Cursor::new(&sec.data);
+        let mut dec = Decoder::from(&mut curs);
+
+        let mut tir_map = HashMap::new();
+        let mut main_defid = None;
+        while let Some(pack) = dec.next().unwrap() {
+            let Pack::Body(body) = pack;
+
+            if body.def_path_str == "main" {
+                main_defid = Some(body.def_id.clone());
+            }
+            tir_map.insert(body.def_id.clone(), body);
+        }
+
+        Self {
+            tir_map: tir_map,
+            main_defid: main_defid.expect("Couldn't find main()"),
+        }
+    }
+
+    /// Start interpreting TIR from the `main()` function.
+    fn run(&self) {
+        let mut stack = Vec::new();
+        stack.push(Frame::new(&self.tir_map[&self.main_defid]));
+
+        // The main interpreter loop.
+        loop {
+            let cur_frame = stack.last().unwrap();
+            let cur_block = &cur_frame.body.blocks[usize::try_from(cur_frame.pc.0).unwrap()];
+            let block_len = cur_block.stmts.len();
+            let pc_stmt_usize = usize::try_from(cur_frame.pc.1).unwrap();
+
+            if pc_stmt_usize < block_len {
+                let stmt = &cur_block.stmts[pc_stmt_usize];
+                self.interp_stmt(stmt);
+            } else if pc_stmt_usize == block_len {
+                // We take statement index one past the end to mean the block terminator.
+                let term = &cur_block.term;
+                self.interp_term(term);
+            } else {
+                unreachable!();
+            }
+        }
+    }
+
+    /// Interpret the specified statement.
+    fn interp_stmt(&self, _stmt: &Statement) {
+        unimplemented!();
+    }
+
+    /// Interpret the specified terminator.
+    fn interp_term(&self, _term: &Terminator) {
+        unimplemented!();
+    }
+}
+
+fn main() {
+    let bin = std::env::args().skip(1).next().unwrap();
+    Interp::new(&PathBuf::from(bin)).run();
+}

--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-fallible-iterator = "0.1"
+fallible-iterator = "0.2"
 
 # We are using a git version to work around a bug:
 # https://github.com/3Hren/msgpack-rust/issues/183

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -15,6 +15,7 @@ use std::fmt::{self, Display};
 pub type CrateHash = u64;
 pub type DefIndex = u32;
 pub type BasicBlockIndex = u32;
+pub type StatementIndex = usize;
 pub type LocalIndex = u32;
 pub type TyIndex = u32;
 pub type FieldIndex = u32;
@@ -80,7 +81,7 @@ impl Display for Local {
 }
 
 /// A mirror of the compiler's notion of a "definition ID".
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
 pub struct DefId {
     pub crate_hash: CrateHash,
     pub def_idx: DefIndex,


### PR DESCRIPTION
> A preliminary design for a TIR trace interpreter.
>
> This is designed only to show that the traces we are collecting are somewhat sane, and as such I've put zero effort into trying to make it fast.
>
> In the long run we will have a TIR trace *compiler*.

What do you think of the design? A few notes:

 * The stack works out quite nicely. Since all temporary computations get stored into TIR locals, and we know how many of those there are ahead of time, there's no need to have a growable/shrinkable frame, nor is there a need to figure out how big each frame needs to be.

 * Each frame has a program counter, which can double up as return address storage.

 * The interpreter struct itself is immutable, and all mutable state is in the scope of the `run()` function. This (I hope) should make it easier to dodge the borrow checker.

Thanks.