### PR TITLE
Mir trace to tir frag boilerplate

### DIFF
--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2"
+elf = "0.0"
+fallible-iterator = "0.2"
+ykpack = { path = "../ykpack" }
+lazy_static = "1.3"

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -86,7 +86,7 @@ impl ThreadTracer {
 }
 
 // An generic interface which tracing backends must fulfill.
-pub trait ThreadTracerImpl {
+trait ThreadTracerImpl {
     /// Stops tracing on the current thread, returning the MIR trace on success. `None` is returned
     /// on error or if the trace was invalidated.
     fn stop_tracing(&self) -> Option<Box<dyn MirTrace>>;

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -27,7 +27,7 @@ pub trait MirTrace {
 
 /// An iterator over a MIR trace.
 pub struct MirTraceIntoIter<'a> {
-    trace: &'a MirTrace,
+    trace: &'a dyn MirTrace,
     next_idx: usize
 }
 

--- a/yktrace/src/swt.rs
+++ b/yktrace/src/swt.rs
@@ -41,7 +41,7 @@ impl Drop for SWTMirTrace {
 struct SWTThreadTracer;
 
 impl ThreadTracer for SWTThreadTracer {
-    fn stop_tracing(self: Box<Self>) -> Option<Box<dyn MirTrace>> {
+    fn stop_tracing_impl(self: Box<Self>) -> Option<Box<dyn MirTrace>> {
         yk_swt::stop_tracing()
             .map(|(buf, len)| Box::new(SWTMirTrace { buf, len }) as Box<dyn MirTrace>)
     }

--- a/yktrace/src/swt.rs
+++ b/yktrace/src/swt.rs
@@ -9,7 +9,7 @@
 
 //! Software tracing via ykrustc.
 
-use super::{MirTrace, ThreadTracer};
+use super::{MirTrace, ThreadTracerImpl, ThreadTracer};
 use core::yk_swt::{self, MirLoc};
 use libc;
 use std::ops::Drop;
@@ -41,16 +41,16 @@ impl Drop for SWTMirTrace {
 /// Softare thread tracer.
 struct SWTThreadTracer;
 
-impl ThreadTracer for SWTThreadTracer {
-    fn stop_tracing_impl(self: Box<Self>) -> Option<Box<dyn MirTrace>> {
+impl ThreadTracerImpl for SWTThreadTracer {
+    fn stop_tracing(&self) -> Option<Box<dyn MirTrace>> {
         yk_swt::stop_tracing()
             .map(|(buf, len)| Box::new(SWTMirTrace { buf, len }) as Box<dyn MirTrace>)
     }
 }
 
-pub fn start_tracing() -> Box<dyn ThreadTracer> {
+pub fn start_tracing() -> ThreadTracer {
     yk_swt::start_tracing();
-    Box::new(SWTThreadTracer {})
+    ThreadTracer{t_impl: Box::new(SWTThreadTracer {})}
 }
 
 #[cfg(test)]

--- a/yktrace/src/swt.rs
+++ b/yktrace/src/swt.rs
@@ -7,8 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Software tracing via ykrustc.
+
 use super::{MirTrace, ThreadTracer};
-/// Software tracing via ykrustc.
 use core::yk_swt::{self, MirLoc};
 use libc;
 use std::ops::Drop;

--- a/yktrace/src/tir_specialise.rs
+++ b/yktrace/src/tir_specialise.rs
@@ -1,0 +1,60 @@
+// Copyright 2019 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Specialising TIR for a MIR trace.
+//!
+//! This module takes a trace of MIR locations and converts it into a specialised "TIR Fragment"
+//! using the TIR found in the `.yk_tir` section of the currently running executable.
+
+use super::{MirTrace};
+use fallible_iterator::FallibleIterator;
+use ykpack::{Body, DefId, Decoder, Pack};
+use elf;
+use std::collections::HashMap;
+use std::env;
+use std::io::Cursor;
+
+/// A TIR fragment is a chunk of TIR specialised to a particular trace of MIR locations. Each
+/// fragment contains only the TIR blocks touched by the MIR trace. Branches not taken manifest as
+/// guards in the fragment.
+/// FIXME the exact representation needs to be decided.
+pub struct TirFrag {}
+
+// The TirMap lets us look up a TIR body from the MIR DefId.
+// The map is immutable and unique to the executable binary being traced.
+lazy_static! {
+    static ref TIR_MAP: HashMap<DefId, Body> = {
+        let ef = elf::File::open_path(env::current_exe().unwrap()).unwrap();
+        let sec = ef.get_section(".yk_tir").expect("Can't find TIR section");
+        let mut curs = Cursor::new(&sec.data);
+        let mut dec = Decoder::from(&mut curs);
+
+        let mut tir_map = HashMap::new();
+        while let Some(pack) = dec.next().unwrap() {
+            let Pack::Body(body) = pack;
+            tir_map.insert(body.def_id.clone(), body);
+        }
+        tir_map
+    };
+}
+
+/// The TIR Specialiser takes a trace of MIR locations and returns a TIR fragment.
+pub struct TirSpecialiser<'t> {
+    _trace: &'t dyn MirTrace,
+}
+
+impl<'t> TirSpecialiser<'t> {
+    pub (crate) fn new(trace: &'t dyn MirTrace) -> Self {
+        Self { _trace: trace }
+    }
+
+    pub (crate) fn specialise(&self) -> TirFrag {
+        unimplemented!() // FIXME: Use the TIR_MAP to make a TirFrag.
+    }
+}


### PR DESCRIPTION
I'm raising this PR quite early so that we can discuss the design.

The way I envisage the TIR interpreter working is as follows:

 * Language interpreter written in our framework eventually decides to trace.
 * Tracing completes, yielding a MIR trace: a trace of MIR block locations.
 * We take the TIR from the ELF file and specialise it the the trace, yielding a *TIR Fragment*.
 * Next time we encounter the hot path, we interpret the TIR fragment.

A couple of items for discussion:

## The name "Tir Fragment"

Why not "TIR Trace"? As discussed the other day on MM, the TIR equivalent of a MIR trace isn't necessarily straight line code, so calling it a trace would be misleading.

I also considered "Tirlet".

## Trait fun.

The following trait irritates me:

```
/// Represents a thread which is currently tracing.                                 
pub trait ThreadTracer {                                                            
    /// Stops tracing on the current thread, returning the MIR trace on success. `None` is returned    
    /// on error or if the trace was invalidated. **The consumers should not call this**.    
    fn stop_tracing_impl(self: Box<Self>) -> Option<Box<dyn MirTrace>>;             
    /// Stops tracing on the current thread, returning a specialised TIR fragment on success.    
    /// Returns `None` if the trace was invalidated. **Do not override this**.      
    fn stop_tracing(self: Box<Self>) -> Option<TirFrag> {                           
        self.stop_tracing_impl().map(|mir_trace| TirSpecialiser::new(&*mir_trace).specialise())    
    }                                                                               
}
```

Notice the "Consumers should not call this" and "Do not override this" comments? I couldn't get the design I wanted using the Rust type system:

 * `stop_tracing` is the same for all backends.
 * `stop_tracing_impl` is specific to a backend, but shouldn't be part of the public API.

To get the desired API, what we could do is wrap `ThreadTracer` in another struct. Thoughts?