### PR TITLE
Kill unwind edges/terminators, add stuff needed for guards.

### DIFF
--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
 
     // Makes some sample stuff to round trip test.
     fn get_sample_packs() -> Vec<Pack> {
-        let dummy_term = Terminator::Abort;
+        let dummy_term = Terminator::Goto(10);
 
         let stmts1_b1 = vec![Statement::Nop; 16];
         let stmts1_b2 = vec![Statement::Nop; 3];
@@ -132,7 +132,7 @@ mod tests {
             ),
             Statement::Nop,
         ];
-        let term_t1_b0 = Terminator::Abort;
+        let term_t1_b0 = Terminator::Goto(20);
         let stmts_t1_b1 = vec![
             Statement::Assign(Local::new(5, 0), Rvalue::Load(Local::new(6, 0))),
             Statement::Store(Local::new(5, 0), Operand::Local(Local::new(4, 0))),
@@ -190,7 +190,7 @@ mod tests {
         $2: t0 = get_field($3: t0, 4)
         $4: t0 = U8(10)
         nop
-        abort
+        goto bb20
     bb1:
         $5: t0 = load($6: t0)
         store($5: t0, $4: t0)


### PR DESCRIPTION
This PR should be merged before the companion PR.

Companion PR: https://github.com/softdevteam/ykrustc/pull/32

This change does three things:

## Remove all unwind/cleanup edges and terminators.

As mentioned in a face-to-face, we are going to use the abort panic strategy for our system. There's a handful of things in terminators which we therefore no longer care about:

 * Terminators soley for unwinding: `Abort` and `Resume`.
 * Edges out of terminators which only apply if there's the possibility of unwinding (`cleanup` and `unwind` edges).

## Add stuff that we will need for guards.

There were some bits missing from some terminators which we need to generate guards.

Example:

An `Assert` terminator has a condition, which we will need to guard. Add this field.

## Add missing info from Drop terminators.

The location-related fields were missing from `Drop` and `DropAndReplace`.