### PR TITLE
Start making TIR traces.

### DIFF
--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -30,6 +30,8 @@
 //!  The version field is automatically written and checked by the `Encoder` and `Decoder`
 //!  respectively.
 
+#![feature(yk_swt)]
+
 mod decode;
 mod encode;
 mod types;

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -9,6 +9,7 @@
 
 //! Types for the Yorick intermediate language.
 
+use core::yk_swt::SirLoc;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
@@ -93,6 +94,11 @@ impl DefId {
             crate_hash,
             def_idx,
         }
+    }
+
+    /// Creates a DefId from an SirLoc, discarding the block index.
+    pub fn from_sir_loc(loc: &SirLoc) -> Self {
+        Self::new(loc.crate_hash(), loc.def_idx())
     }
 }
 

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -26,7 +26,7 @@ use tir::TirTrace;
 pub trait SirTrace {
     /// Returns the length of the trace, measured in SIR locations.
     fn len(&self) -> usize;
-    /// Returns the SIR location and index `idx`.
+    /// Returns the SIR location at index `idx`.
     fn loc(&self, idx: usize) -> &SirLoc;
 }
 
@@ -83,7 +83,7 @@ impl ThreadTracer {
     pub fn stop_tracing(self) -> Option<TirTrace> {
         self.t_impl
             .stop_tracing()
-            .map(|mir_trace| TirTrace::new(&*mir_trace))
+            .map(|mir_trace| TirTrace::new(&*mir_trace).ok().unwrap())
     }
 }
 

--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -14,15 +14,17 @@
 use super::SirTrace;
 use elf;
 use fallible_iterator::FallibleIterator;
-use std::{collections::HashMap, env, io::Cursor};
-use ykpack::{Body, Decoder, DefId, Pack};
+use std::{collections::HashMap, convert::TryFrom, env, io::Cursor};
+#[cfg(debug_assertions)]
+use ykpack::{BasicBlockIndex, Terminator};
+use ykpack::{Body, Decoder, DefId, Pack, Statement};
 
 // The SIR Map lets us look up a SIR body from the SIR DefId.
 // The map is unique to the executable binary being traced (i.e. shared for all threads).
 lazy_static! {
     static ref SIR_MAP: HashMap<DefId, Body> = {
         let ef = elf::File::open_path(env::current_exe().unwrap()).unwrap();
-        let sec = ef.get_section(".yk_tir").expect("Can't find TIR section");
+        let sec = ef.get_section(".yk_sir").expect("Can't find SIR section");
         let mut curs = Cursor::new(&sec.data);
         let mut dec = Decoder::from(&mut curs);
 
@@ -36,18 +38,95 @@ lazy_static! {
 }
 
 /// A TIR trace is conceptually a straight-line path through the SIR with guarded speculation.
+#[derive(Debug)]
 pub struct TirTrace {
-    _stmts: Vec<_TirOp>
+    ops: Vec<TirOp>
 }
 
 impl TirTrace {
-    pub(crate) fn new(_trace: &'_ dyn SirTrace) -> Self {
-        // FIXME: Use the SIR_MAP to convert the SirTrace to a TirTrace.
-        unimplemented!()
+    /// Create a TirTrace from a SirTrace.
+    /// Returns Err if a DefId is encountered for which no SIR is available. In the error case, the
+    /// trace built thus-far is returned inside the error.
+    ///
+    /// FIXME: This is not the final "intended" API. Normally we wouldn't care about the trace
+    /// built thus-far in an error case, but since we have no sensible way to stop the tracer at
+    /// the right time, inevitably traces can shoot off into code which has no SIR. In turn this
+    /// invalidates the trace. We only return the trace built so far in the interim.
+    pub(crate) fn new(trace: &'_ dyn SirTrace) -> Result<Self, Self> {
+        let mut ops = Vec::new();
+        let num_locs = trace.len();
+
+        for blk_idx in 0..num_locs {
+            let loc = trace.loc(blk_idx);
+            let body = match SIR_MAP.get(&DefId::from_sir_loc(loc)) {
+                Some(b) => b,
+                None => return Err(Self { ops })
+            };
+
+            let shadow_bb_idx_usize = usize::try_from(loc.bb_idx()).unwrap();
+            // Here we use an invariant of the MIR transform to find the user block for a shadow
+            // block. In the blocks vector, first come N shadow blocks, then come N corresponding
+            // user blocks. The debug assertion checks the invariant holds by looking at where the
+            // shadow block returns to after the call to the trace recorder.
+            let user_bb_idx_usize = body.blocks.len() / 2 + shadow_bb_idx_usize;
+            #[cfg(debug_assertions)]
+            match body.blocks[shadow_bb_idx_usize].term {
+                Terminator::Call { ret_bb, .. } => debug_assert!(
+                    ret_bb == Some(BasicBlockIndex::try_from(user_bb_idx_usize).unwrap())
+                ),
+                _ => panic!("shadow invariant doesn't hold")
+            }
+
+            // When adding statements to the trace, we clone them (rather than referencing the
+            // statements in the SIR_MAP) so that we have the freedom to mutate them later.
+            ops.extend(
+                body.blocks[user_bb_idx_usize]
+                    .stmts
+                    .iter()
+                    .cloned()
+                    .map(TirOp::Statement)
+            );
+
+            // FIXME: Convert the block terminator to a guard if necessary.
+        }
+        Ok(Self { ops })
+    }
+
+    /// Return the length of the trace measure in operations.
+    pub fn len(&self) -> usize {
+        self.ops.len()
     }
 }
 
 /// A TIR operation. A collection of these makes a TIR trace.
-pub enum _TirOp {
-    // FIXME: implement innards.
+#[derive(Debug)]
+pub enum TirOp {
+    Statement(Statement) // FIXME guards
+}
+
+#[cfg(test)]
+mod tests {
+    // Some work to trace.
+    #[inline(never)]
+    fn work(x: usize, y: usize) -> usize {
+        let mut res = 0;
+        while res < y {
+            res += x;
+        }
+        res
+    }
+
+    use crate::{start_tracing, TirTrace, TracingKind};
+    use test::black_box;
+
+    #[test]
+    fn nonempty_tir_trace() {
+        let tracer = start_tracing(Some(TracingKind::SoftwareTracing));
+        let res = black_box(work(black_box(3), black_box(13)));
+        let sir_trace = tracer.t_impl.stop_tracing().unwrap();
+        let tir_trace = TirTrace::new(&*sir_trace).unwrap();
+        assert_eq!(res, 15);
+        dbg!(tir_trace.len());
+        assert!(tir_trace.len() > 0);
+    }
 }


### PR DESCRIPTION
This change starts building TIR traces by coping the relevant SIR statements into a TirTrace.

 * Guards are not yet implemented.
 * Tracing currently always yields invalid traces because we don't have a proper way to stop tracing at a merge point: we always hit a function for which we have no SIR, meaning that the trace is invalid. There is an API compromise so that we can test *something* in the interim.

No companion PR for this one :)