### PR TITLE
Yk SIR debug

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -8,3 +8,4 @@ export PATH=`pwd`/ykrustc-stage2-latest/bin:${PATH}
 
 cargo fmt --all -- --check
 cargo test
+cargo test --release

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -501,16 +501,50 @@ impl Display for BinOp {
     }
 }
 
+/// A debugging entry, mapping a DefId to its definition path string.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct SirDebug {
+    def_id: DefId,
+    def_path: String,
+}
+
+impl SirDebug {
+    pub fn new(def_id: DefId, def_path: String) -> Self {
+        Self { def_id, def_path }
+    }
+
+    pub fn def_id(&self) -> &DefId {
+        &self.def_id
+    }
+
+    pub fn def_path(&self) -> &str {
+        &self.def_path
+    }
+}
+
 /// The top-level pack type.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum Pack {
     Body(Body),
+    Debug(SirDebug),
+}
+
+impl Display for SirDebug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "<debug: def_id={}, def_path_str={}>",
+            self.def_id, self.def_path
+        )
+    }
 }
 
 impl Display for Pack {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Pack::Body(sir) = self;
-        write!(f, "{}", sir)
+        match self {
+            Pack::Body(sir) => write!(f, "{}", sir),
+            Pack::Debug(dbg) => write!(f, "{}", dbg),
+        }
     }
 }
 

--- a/yktrace/src/debug.rs
+++ b/yktrace/src/debug.rs
@@ -1,0 +1,79 @@
+// Copyright 2019 King's College London.
+// Created by the Software Development Team <http://soft-dev.org/>.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Debugging utilities.
+
+use crate::SirTrace;
+use elf;
+use fallible_iterator::FallibleIterator;
+use std::{collections::HashMap, env, io::Cursor};
+pub use ykpack::Statement;
+use ykpack::{Decoder, DefId, Pack};
+
+// The SIR Debug Map lets us map a DefId to a definition path.
+// This is read from the .yk_sir ELF section.
+lazy_static! {
+    static ref SIR_DEBUG_MAP: HashMap<DefId, String> = {
+        let ef = elf::File::open_path(env::current_exe().unwrap()).unwrap();
+        let sec = ef.get_section(".yk_sir").expect("Can't find SIR section");
+        let mut curs = Cursor::new(&sec.data);
+        let mut dec = Decoder::from(&mut curs);
+
+        let mut sir_dbg_map = HashMap::new();
+        while let Some(pack) = dec.next().unwrap() {
+            match pack {
+                Pack::Body(_) => (),
+                Pack::Debug(d) => {
+                    let old = sir_dbg_map.insert(d.def_id().clone(), String::from(d.def_path()));
+                    debug_assert!(old.is_none()); // should be no duplicates.
+                },
+            }
+        }
+        sir_dbg_map
+    };
+}
+
+/// Given a DefId, get the definition path.
+pub fn def_path(def_id: &DefId) -> Option<&str> {
+    SIR_DEBUG_MAP
+        .get(def_id)
+        .as_ref()
+        .map(|s| String::as_str(s))
+}
+
+/// Prints a SIR trace to stdout for debugging purposes.
+pub fn print_sir_trace(trace: &dyn SirTrace) {
+    println!("---[ BEGIN SIR TRACE DUMP ]---");
+    for loc in trace {
+        let def_id = DefId::from_sir_loc(&loc);
+        let def_path_s = match def_path(&def_id) {
+            Some(s) => s,
+            None => "<unknown>"
+        };
+        println!(
+            "[{}] crate={}, index={}, bb={}",
+            def_path_s,
+            loc.crate_hash(),
+            loc.def_idx(),
+            loc.bb_idx()
+        );
+    }
+    println!("---[ END SIR TRACE DUMP ]---");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SIR_DEBUG_MAP;
+
+    /// This just checks loading the SIR debug map doesn't crash.
+    #[test]
+    fn test_load_debug_map() {
+        let _ = SIR_DEBUG_MAP.iter().len();
+    }
+}

--- a/yktrace/src/errors.rs
+++ b/yktrace/src/errors.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::debug;
 use std::fmt::{self, Display, Formatter};
 use ykpack::DefId;
 
@@ -14,15 +15,28 @@ use ykpack::DefId;
 /// Reasons that a trace can be invalidated.
 pub enum InvalidTraceError {
     /// There is no SIR for the DefId of a location in the trace.
-    NoSir(DefId),
+    /// The second element is the definition path string.
+    NoSir(DefId, String),
     /// Something went wrong in the compiler's tracing code
     InternalError
+}
+
+impl InvalidTraceError {
+    /// A helper function to create a `InvalidTraceError::NoSir`.
+    pub fn no_sir(def_id: &DefId) -> Self {
+        return InvalidTraceError::NoSir(
+            def_id.clone(),
+            String::from(debug::def_path(def_id).unwrap_or("<unknown>"))
+        );
+    }
 }
 
 impl Display for InvalidTraceError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            InvalidTraceError::NoSir(def_id) => write!(f, "No SIR for location: {}", def_id),
+            InvalidTraceError::NoSir(def_id, def_path) => {
+                write!(f, "No SIR for location: {} ({})", def_id, def_path)
+            }
             InvalidTraceError::InternalError => write!(f, "Internal tracing error")
         }
     }

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -20,6 +20,7 @@ use std::{
 #[macro_use]
 extern crate lazy_static;
 
+pub mod debug;
 mod errors;
 mod swt;
 pub mod tir;


### PR DESCRIPTION
This add debugging structures and routines to help with development going forward.

It helps me map DefIds to a human readable names (their definition paths). I've also added a function which prints the names for a whole SIR trace.

Example output:
```
---[ BEGIN SIR TRACE DUMP ]---
[<unknown>] crate=9716225740442656270, index=51, bb=1
[<unknown>] crate=5705253629357860373, index=81, bb=0
[<unknown>] crate=5705253629357860373, index=35, bb=0
[<unknown>] crate=5705253629357860373, index=35, bb=1
[<unknown>] crate=5705253629357860373, index=35, bb=8
[<unknown>] crate=9716225740442656270, index=51, bb=2
[<unknown>] crate=9716225740442656270, index=121, bb=8
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=2
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=3
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=0
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=3
[tests::work] crate=12828469188679359606, index=39, bb=4
[tests::work] crate=12828469188679359606, index=39, bb=1
[tests::work] crate=12828469188679359606, index=39, bb=2
[tests::interp_simple_trace] crate=12828469188679359606, index=43, bb=5
[<unknown>] crate=9716225740442656270, index=117, bb=0
[<unknown>] crate=9716225740442656270, index=50, bb=0
---[ END SIR TRACE DUMP ]---
```

[Here I can immediately see the function I was aiming to trace, `work()`, but also test suite code either side, and then the troublesome "unknown" code.]

This works by adding new debugging pack records. These are emiited unconditionally for now, as I'm going to need this for the foreseeable future. It's also enabled for debug builds, as we will need to debug both build types (the code we trace differs according to the mode).

I'm about 99% sure this is another circular merge between ykrustc and yk, so I'm going to raise this as a draft and ask bors to try it.

A companion PR will follow. Here: https://github.com/softdevteam/ykrustc/pull/34