### PR TITLE
Use the latest release of rmp-serde.

### DIFF
--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -7,9 +7,4 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 fallible-iterator = "0.2"
-
-# We are using a git version to work around a bug:
-# https://github.com/3Hren/msgpack-rust/issues/183
-[dependencies.rmp-serde]
-git = "https://github.com/3Hren/msgpack-rust"
-rev = "40b3d480b20961e6eeceb416b32bcd0a3383846a"
+rmp-serde = "0.14"


### PR DESCRIPTION
We are free to do this now that this bug is fixed:
https://github.com/3Hren/msgpack-rust/issues/183

Don' review yet. I want to see if this will cause a CI problem.