### PR TITLE
Sir changes

### DIFF
--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -71,12 +71,14 @@ mod tests {
             BasicBlock::new(stmts1_b1, dummy_term.clone()),
             BasicBlock::new(stmts1_b2, dummy_term.clone()),
         ];
-        let sir1 = Pack::Body(Body::new(
-            DefId::new(1, 2),
-            String::from("item1"),
-            blocks1,
-            0,
-        ));
+        let sir1 = Pack::Body(Body {
+            def_id: DefId::new(1, 2),
+            def_path_str: String::from("item1"),
+            blocks: blocks1,
+            num_args: 3,
+            num_locals: 4,
+            flags: 0,
+        });
 
         let stmts2_b1 = vec![Statement::Nop; 7];
         let stmts2_b2 = vec![Statement::Nop; 200];
@@ -86,12 +88,14 @@ mod tests {
             BasicBlock::new(stmts2_b2, dummy_term.clone()),
             BasicBlock::new(stmts2_b3, dummy_term.clone()),
         ];
-        let sir2 = Pack::Body(Body::new(
-            DefId::new(4, 5),
-            String::from("item2"),
-            blocks2,
-            0,
-        ));
+        let sir2 = Pack::Body(Body {
+            def_id: DefId::new(4, 5),
+            def_path_str: String::from("item2"),
+            blocks: blocks2,
+            num_args: 8,
+            num_locals: 9,
+            flags: 0,
+        });
 
         vec![sir1, sir2]
     }
@@ -174,21 +178,25 @@ mod tests {
         ];
 
         let sirs = vec![
-            Pack::Body(Body::new(
-                DefId::new(1, 2),
-                String::from("item1"),
-                blocks_t1,
-                0,
-            )),
-            Pack::Body(Body::new(
-                DefId::new(3, 4),
-                String::from("item2"),
-                vec![BasicBlock::new(
+            Pack::Body(Body {
+                def_id: DefId::new(1, 2),
+                def_path_str: String::from("item1"),
+                blocks: blocks_t1,
+                num_args: 100,
+                num_locals: 200,
+                flags: 0,
+            }),
+            Pack::Body(Body {
+                def_id: DefId::new(3, 4),
+                def_path_str: String::from("item2"),
+                blocks: vec![BasicBlock::new(
                     vec![Statement::Unimplemented(String::from("abc"))],
                     Terminator::Unreachable,
                 )],
-                0,
-            )),
+                num_args: 9,
+                num_locals: 15,
+                flags: 0,
+            }),
         ];
 
         let mut got = String::new();

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -121,18 +121,12 @@ pub struct Body {
     pub def_id: DefId,
     pub def_path_str: String,
     pub blocks: Vec<BasicBlock>,
+    /// The number of arguments to the function.
+    pub num_args: usize,
+    /// The number of local variables used by the function, including the return value and
+    /// arguments.
+    pub num_locals: usize,
     pub flags: u8,
-}
-
-impl Body {
-    pub fn new(def_id: DefId, def_path_str: String, blocks: Vec<BasicBlock>, flags: u8) -> Self {
-        Self {
-            def_id,
-            def_path_str,
-            blocks,
-            flags,
-        }
-    }
 }
 
 impl Display for Body {


### PR DESCRIPTION
These changes are the first phase needed to have a proof of concept TIR interpreter (in the long run we will *compile* traces, and these changes help there too).

A companion PR will follow and I also expect this to make a [CI cycle](https://github.com/softdevteam/ykrustc/wiki/Continuous-Integration-Cycles).

Companion PR: https://github.com/softdevteam/ykrustc/pull/60

Previously, the on-disk SIR had included calls to to trace recorder if software tracing was in effect. This meant that I had to unpick the SIR structure at runtime and besides, we don't actually care to trace the trace recorder. I realised that I could just encode SIR in such a way that the calls to the trace recorder don't appear.

Second, when a trace follows a function call, the callee has its own local variables but with indices which would clash with the caller's. In order to interpret or compile the trace we'd have to do *something* so that the callee doesn't hose the caller's variables. How we do this, using a stack or variable renaming, doesn't matter for now, but either way, we need to know how many arguments and how many local variables each function uses. 