### PR TITLE
Remove the type tag in the local struct.

### DIFF
--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -140,19 +140,16 @@ mod tests {
     #[test]
     fn test_text_dump() {
         let stmts_t1_b0 = vec![
+            Statement::Assign(Place::from(Local(0)), Rvalue::from(Local(1))),
             Statement::Assign(
-                Place::from(Local::new(0, 0)),
-                Rvalue::from(Local::new(1, 0)),
-            ),
-            Statement::Assign(
-                Place::from(Local::new(2, 0)),
+                Place::from(Local(2)),
                 Rvalue::Use(Operand::Place(Place {
-                    base: PlaceBase::Local(Local::new(3, 0)),
+                    base: PlaceBase::Local(Local(3)),
                     projections: vec![PlaceProjection::Field(4)],
                 })),
             ),
             Statement::Assign(
-                Place::from(Local::new(4, 0)),
+                Place::from(Local(4)),
                 Rvalue::Use(Operand::Constant(Constant::Int(ConstantInt::UnsignedInt(
                     UnsignedInt::U8(10),
                 )))),
@@ -161,32 +158,22 @@ mod tests {
         ];
         let term_t1_b0 = Terminator::Goto(20);
         let stmts_t1_b1 = vec![
+            Statement::Assign(Place::from(Local(5)), Rvalue::from(Local(6))),
+            Statement::Assign(Place::from(Local(5)), Rvalue::from(Local(4))),
             Statement::Assign(
-                Place::from(Local::new(5, 0)),
-                Rvalue::from(Local::new(6, 0)),
+                Place::from(Local(7)),
+                Rvalue::BinaryOp(BinOp::Add, Operand::from(Local(8)), Operand::from(Local(9))),
             ),
             Statement::Assign(
-                Place::from(Local::new(5, 0)),
-                Rvalue::from(Local::new(4, 0)),
-            ),
-            Statement::Assign(
-                Place::from(Local::new(7, 0)),
-                Rvalue::BinaryOp(
-                    BinOp::Add,
-                    Operand::from(Local::new(8, 0)),
-                    Operand::from(Local::new(9, 0)),
-                ),
-            ),
-            Statement::Assign(
-                Place::from(Local::new(7, 0)),
+                Place::from(Local(7)),
                 Rvalue::BinaryOp(
                     BinOp::Sub,
-                    Operand::from(Local::new(9, 0)),
-                    Operand::from(Local::new(10, 0)),
+                    Operand::from(Local(9)),
+                    Operand::from(Local(10)),
                 ),
             ),
             Statement::Assign(
-                Place::from(Local::new(11, 0)),
+                Place::from(Local(11)),
                 Rvalue::Use(Operand::Constant(Constant::Int(ConstantInt::u8_from_bits(
                     0,
                 )))),
@@ -230,17 +217,17 @@ mod tests {
         let expect = "[Begin SIR for item1]\n\
     DefId(1, 2):
     bb0:
-        $0: t0 = $1: t0
-        $2: t0 = ($3: t0).4
-        $4: t0 = U8(10)
+        $0 = $1
+        $2 = ($3).4
+        $4 = U8(10)
         nop
         goto bb20
     bb1:
-        $5: t0 = $6: t0
-        $5: t0 = $4: t0
-        $7: t0 = add($8: t0, $9: t0)
-        $7: t0 = sub($9: t0, $10: t0)
-        $11: t0 = U8(0)
+        $5 = $6
+        $5 = $4
+        $7 = add($8, $9)
+        $7 = sub($9, $10)
+        $11 = U8(0)
         goto bb50
 [End SIR for item1]
 [Begin SIR for item2]

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -56,28 +56,11 @@ new_ser128!(SerU128, u128);
 new_ser128!(SerI128, i128);
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
-pub struct Local {
-    idx: LocalIndex,
-    ty: TyIndex,
-}
-
-impl Local {
-    pub fn new(idx: LocalIndex, ty: TyIndex) -> Self {
-        Self { idx, ty }
-    }
-
-    pub fn idx(&self) -> LocalIndex {
-        self.idx
-    }
-
-    pub fn ty(&self) -> TyIndex {
-        self.ty
-    }
-}
+pub struct Local(pub LocalIndex);
 
 impl Display for Local {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "${}: t{}", self.idx, self.ty)
+        write!(f, "${}", self.0)
     }
 }
 


### PR DESCRIPTION
Let's get rid of that pesky type tag we discussed in the last PR. See the commit message for more info.

This requires a compiler change (coming soon) and due to Sir changes, a 3-phase PR.