### PR TITLE
Add hardware tracer

### DIFF
--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -10,3 +10,8 @@ elf = "0.0"
 fallible-iterator = "0.2"
 ykpack = { path = "../ykpack" }
 lazy_static = "1.3"
+hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
+phdrs = { git = "https://github.com/softdevteam/phdrs" }
+gimli = "0.19.0"
+object = "0.14.0"
+memmap = "0.7.0"

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -1,0 +1,139 @@
+use object::Object;
+use phdrs::objects;
+
+use core::yk::SirLoc;
+use hwtracer::Trace;
+use std::{borrow, collections::HashMap, env, fs};
+
+pub struct HWTMapper {
+    phdr_offset: u64,
+    labels: Option<HashMap<u64, String>>
+}
+
+impl HWTMapper {
+    pub fn new() -> HWTMapper {
+        let phdr_offset = get_phdr_offset();
+        let labels = match extract_labels() {
+            Ok(l) => Some(l),
+            Err(_) => None
+        };
+        HWTMapper {
+            phdr_offset,
+            labels
+        }
+    }
+
+    /// Maps each entry of a hardware trace to the appropriate SirLoc.
+    pub fn map(&self, trace: Box<dyn Trace>) -> Option<Vec<SirLoc>> {
+        if !self.labels.is_some() {
+            return None;
+        }
+        let labels = self.labels.as_ref().unwrap();
+        let mut annotrace = Vec::new();
+        for b in trace.iter_blocks() {
+            match b {
+                Ok(block) => {
+                    let addr = block.start_vaddr() - self.phdr_offset;
+                    match labels.get(&addr) {
+                        Some(l) => {
+                            let data: Vec<&str> = l[9..].split('_').collect();
+                            let crate_hash = u64::from_str_radix(data[0], 16).unwrap();
+                            let def_idx = data[1].parse::<u32>().unwrap();
+                            let bb_idx = data[2].parse::<u32>().unwrap();
+                            annotrace.push(SirLoc::new(crate_hash, def_idx, bb_idx))
+                        }
+                        None => {}
+                    };
+                }
+                Err(_) => {}
+            }
+        }
+        Some(annotrace)
+    }
+}
+
+/// Extract the program header offset. This offset can be used to translate the address of a trace
+/// block to a program address, allowing us to find the correct SIR location.
+fn get_phdr_offset() -> u64 {
+    (&objects()[0]).addr() as u64
+}
+
+/// Extracts YK debug labels and their addresses from the executable.
+fn extract_labels() -> Result<HashMap<u64, String>, gimli::Error> {
+    // Load executable
+    let pathb = env::current_exe().unwrap();
+    let file = fs::File::open(&pathb.as_path()).unwrap();
+    let mmap = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let object = object::File::parse(&*mmap).unwrap();
+    let endian = if object.is_little_endian() {
+        gimli::RunTimeEndian::Little
+    } else {
+        gimli::RunTimeEndian::Big
+    };
+
+    // Extract labels
+    let mut labels = HashMap::new();
+
+    let loader = |id: gimli::SectionId| -> Result<borrow::Cow<[u8]>, gimli::Error> {
+        Ok(object
+            .section_data_by_name(id.name())
+            .unwrap_or(borrow::Cow::Borrowed(&[][..])))
+    };
+    let sup_loader = |_| Ok(borrow::Cow::Borrowed(&[][..]));
+    let dwarf_cow = gimli::Dwarf::load(&loader, &sup_loader)?;
+    let borrow_section: &dyn for<'a> Fn(
+        &'a borrow::Cow<[u8]>
+    ) -> gimli::EndianSlice<'a, gimli::RunTimeEndian> =
+        &|section| gimli::EndianSlice::new(&*section, endian);
+    let dwarf = dwarf_cow.borrow(&borrow_section);
+    let mut iter = dwarf.units();
+    let mut subaddr = None;
+    while let Some(header) = iter.next()? {
+        let unit = dwarf.unit(header)?;
+        let mut entries = unit.entries();
+        while let Some((_, entry)) = entries.next_dfs()? {
+            if entry.tag() == gimli::DW_TAG_subprogram {
+                if let Some(_name) = entry.attr_value(gimli::DW_AT_linkage_name)? {
+                    if let Some(lowpc) = entry.attr_value(gimli::DW_AT_low_pc)? {
+                        let addr = match lowpc {
+                            gimli::AttributeValue::Addr(v) => v as u64,
+                            _ => panic!("Error reading dwarf information. Expected type 'Addr'.")
+                        };
+                        // We can not accurately insert labels at the beginning of functions,
+                        // because the label is offset by the function headers. We thus simply
+                        // remember the subprogram's address so we can later assign it to the first
+                        // block (ending with '_0') of this subprogram.
+                        subaddr = Some(addr);
+                    }
+                }
+            } else if entry.tag() == gimli::DW_TAG_label {
+                if let Some(name) = entry.attr_value(gimli::DW_AT_name)? {
+                    if let Some(es) = name.string_value(&dwarf.debug_str) {
+                        let s = es.to_string()?;
+                        if s.starts_with("__YK_") {
+                            if let Some(lowpc) = entry.attr_value(gimli::DW_AT_low_pc)? {
+                                let addr = match lowpc {
+                                    gimli::AttributeValue::Addr(v) => v as u64,
+                                    _ => panic!(
+                                        "Error reading dwarf information. Expected type 'Addr'."
+                                    )
+                                };
+                                if subaddr.is_some() && s.ends_with("_0") {
+                                    // This is the first block of the subprogram. Assign its label
+                                    // to the subprogram's address.
+                                    labels.insert(subaddr.unwrap(), s.to_string());
+                                    subaddr = None;
+                                } else {
+                                    labels.insert(addr, s.to_string());
+                                }
+                            } else {
+                                // Ignore labels that have now address
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(labels)
+}

--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -250,7 +250,10 @@ mod tests {
 
     #[test]
     fn nonempty_tir_trace() {
-        let tracer = start_tracing(Some(TracingKind::SoftwareTracing));
+        #[cfg(tracermode = "sw")]
+        let mut tracer = start_tracing(Some(TracingKind::SoftwareTracing));
+        #[cfg(tracermode = "hw")]
+        let mut tracer = start_tracing(Some(TracingKind::HardwareTracing));
         let res = black_box(work(black_box(3), black_box(13)));
         let sir_trace = tracer.t_impl.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*sir_trace).unwrap();


### PR DESCRIPTION
This PR adds the hardware tracer to yk. In order to map the hardware trace to SIR locations, we first extract `YK` debug labels from the executable. Each label can be converted to a `SirLoc` which we then assign to the appropriate block in the trace.