### PR TITLE
 Ignore trace_tail test for the hardware tracer

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 # The service providing the commit statuses to GitHub.
 status = [
-  "buildbot/buildbot-build-script"
+  "buildbot/ykrustc-buildbot-build-script-hwt",
+  "buildbot/ykrustc-buildbot-build-script-swt",
 ]
 
 # Allow eight hours for builds + tests.

--- a/tiri/src/lib.rs
+++ b/tiri/src/lib.rs
@@ -368,6 +368,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(tracermode = "sw")] // https://github.com/softdevteam/yk/issues/38
     fn interp_simple_trace() {
         let tracer = start_tracing(Some(TracingKind::SoftwareTracing));
         let res = work(black_box(3), black_box(13));

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -111,6 +111,7 @@ impl ThreadTracer {
 // An generic interface which tracing backends must fulfill.
 trait ThreadTracerImpl {
     /// Stops tracing on the current thread, returning the SIR trace on success.
+    #[trace_tail]
     fn stop_tracing(&mut self) -> Result<Box<dyn SirTrace>, InvalidTraceError>;
 }
 


### PR DESCRIPTION
This is the same PR as #39, which we had to re-raise due to changes in bors. See #39 for more details.