### PR TITLE
Update dependency for object crate

### DIFF
--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -13,5 +13,5 @@ lazy_static = "1.3"
 hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 gimli = "0.19.0"
-object = "0.14.0"
+object = "0.17.0"
 memmap = "0.7.0"


### PR DESCRIPTION
This updates the object crate to version 0.17, since otherwise we can't compile it with hardware tracing enabled.

We could merge this as is, or take the opportunity to update some other crates as well. Thoughts?