### PR TITLE
Improve textual notation of Call targets.

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -354,8 +354,8 @@ pub enum CallOperand {
 impl Display for CallOperand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CallOperand::Fn(sym_name) => write!(f, "sym_name={}", sym_name),
-            CallOperand::Unknown => write!(f, "unknown"),
+            CallOperand::Fn(sym_name) => write!(f, "{}", sym_name),
+            CallOperand::Unknown => write!(f, "<unknown>"),
         }
     }
 }


### PR DESCRIPTION
The textual notation for a Call target is kind of weird.

If there's a known symbol, it looks like this:
```
call operand=sym_name=_ZN50_$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$4into17hcac79ab93d213ca6E, ret_bb=bb23
```

I think `operand=sym_name=` looks weird.

This change kills `sym_name=` and in case of an unknown target uses `<unknown>` (instead of `unknown`).

