### PR TITLE
Start work on assembler backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members=[
     "ykrt",
     "yktrace",
     "tiri",
+    "assembler"
 ]

--- a/assembler/Cargo.toml
+++ b/assembler/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "assembler"
+version = "0.1.0"
+authors = ["Lukas Diekmann <lukas.diekmann@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc = "0.2"

--- a/assembler/src/backend/mod.rs
+++ b/assembler/src/backend/mod.rs
@@ -1,0 +1,11 @@
+mod rasm;
+
+pub enum EncoderBackend {
+    RasmBackend
+}
+
+pub fn encode(backend: EncoderBackend, input: &str) -> Vec<u8> {
+    match backend {
+        EncoderBackend::RasmBackend => rasm::encode(input)
+    }
+}

--- a/assembler/src/backend/rasm.rs
+++ b/assembler/src/backend/rasm.rs
@@ -1,0 +1,10 @@
+use std::process::Command;
+
+pub fn encode(input: &str) -> Vec<u8> {
+    let output = Command::new("/usr/bin/rasm2")
+        .arg("-B")
+        .arg(input)
+        .output()
+        .expect("failed to execute process");
+    output.stdout
+}

--- a/assembler/src/backend/rasm.rs
+++ b/assembler/src/backend/rasm.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 pub fn encode(input: &str) -> Vec<u8> {
-    let output = Command::new("/usr/bin/rasm2")
+    let output = Command::new("rasm2")
         .arg("-B")
         .arg(input)
         .output()

--- a/assembler/src/lib.rs
+++ b/assembler/src/lib.rs
@@ -1,0 +1,79 @@
+use libc;
+use std::mem;
+use std::process::Command;
+
+// getpagesize() (sycall)
+const PAGE_SIZE: usize = 4096;
+
+struct Assembler {
+    memmap: *mut u8,
+    instrptr: usize
+}
+
+impl Assembler {
+
+    pub fn new() -> Self {
+        // Create a single page of memory to store our instructions in and make it writable
+        let memmap = unsafe {
+            let mut page: *mut libc::c_void = mem::MaybeUninit::uninit().as_mut_ptr();
+            libc::posix_memalign(&mut page, PAGE_SIZE, PAGE_SIZE);
+            libc::mprotect(page, PAGE_SIZE, libc::PROT_WRITE);
+
+            // XXX correct use of assume_init()?
+
+            // Transmute to raw u8 pointer
+            let memmap: *mut u8 = mem::transmute(page);
+            memmap
+        };
+
+        Assembler {
+            memmap,
+            instrptr: 0
+        }
+    }
+
+    pub fn add_instruction(&mut self, instr: &str) {
+        let output = Command::new("/usr/bin/rasm2")
+            .arg("-B")
+            .arg(instr)
+            .output()
+            .expect("failed to execute process");
+        let instr = output.stdout.as_ptr();
+        unsafe {
+            let off = self.memmap.offset(self.instrptr as isize);
+            libc::memcpy(off as *mut _, instr as *const _, output.stdout.len());
+        }
+        self.instrptr += output.stdout.len();
+    }
+
+    fn make_executable(&self) {
+        unsafe {
+            libc::mprotect(self.memmap as *mut _, PAGE_SIZE, libc::PROT_EXEC);
+        }
+    }
+
+    fn function_pointer(&self) -> fn() -> i64 {
+        unsafe {
+            mem::transmute(self.memmap)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::Assembler;
+
+    #[test]
+    pub(crate) fn test_basic() {
+        let mut assemb = Assembler::new();
+        assemb.add_instruction("mov rdx, 3");
+        assemb.add_instruction("mov rcx, 4");
+        assemb.add_instruction("add rcx, rdx");
+        assemb.add_instruction("mov rax, rcx");
+        assemb.add_instruction("ret");
+        assemb.make_executable();
+        let func = assemb.function_pointer();
+        assert_eq!(func(), 7);
+    }
+}


### PR DESCRIPTION
**This is work in progress and not ready for merging yet**

This is a very basic outline of our assembler to be used as a replacement for the assembler library I am currently using in my [ykcompile](https://github.com/ptersilie/yk/tree/ykcompile) branch.

Before I dive deeper into this and make decisions I will later regret, I think it would be good to start some discussion on this and think together where we would like this to go and how would like this to work.

One immediately obvious flaw of this API is that any encoder needs to return a `Vec`, which is slow. A solution I see for this is to have the encoder write the machine code directly to memory, which is also not ideal from an API perspective. So I'm open to suggestions here.

Ready...fight!