### PR TITLE
Relax the dependency on rmp-serde.

### DIFF
--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 fallible-iterator = "0.2"
-rmp-serde = "=0.14.0"
+rmp-serde = "0.14"


### PR DESCRIPTION
This is required for an upstream sync.