### PR TITLE
`Display` for `TirTrace`

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -106,7 +106,7 @@ pub enum PlaceElem {
 impl Display for PlaceElem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Unimplemented(s) => write!(f, "unimplemented projection: {:?}", s),
+            Self::Unimplemented(s) => write!(f, ".(unimplemented projection: {:?})", s),
         }
     }
 }

--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -6,7 +6,13 @@ use super::SirTrace;
 use crate::errors::InvalidTraceError;
 use elf;
 use fallible_iterator::FallibleIterator;
-use std::{collections::HashMap, convert::TryFrom, env, fmt, io::Cursor};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    env,
+    fmt::{self, Display},
+    io::Cursor
+};
 use ykpack::{bodyflags, Body, Decoder, Pack, Terminator};
 pub use ykpack::{
     BinOp, Constant, ConstantInt, Local, LocalIndex, Operand, Place, PlaceBase, PlaceElem, Rvalue,
@@ -185,6 +191,16 @@ impl TirTrace {
     /// Return the length of the trace measure in operations.
     pub fn len(&self) -> usize {
         self.ops.len()
+    }
+}
+
+impl Display for TirTrace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "[Start TIR Trace]")?;
+        for op in &self.ops {
+            writeln!(f, "  {}", op)?;
+        }
+        writeln!(f, "[End TIR Trace]")
     }
 }
 


### PR DESCRIPTION
@ptersilie this will make it easier for you to start at traces.

Example TIR trace:
```
[Start TIR Trace]                                                                               [19/1834]
  $2 = unimplemented rvalue: unimplemented rvalue: &_1                                                  
  unimplemented_stmt: asm!(InlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], c
lobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : [(/home/vext01/research/yorick/ykru
stc/src/libcore/hint.rs:116:25: 116:31, move _2)])                                                       
  $0 = $1                                         
  $2 = unimplemented rvalue: unimplemented rvalue: &_1                                                  
  unimplemented_stmt: asm!(InlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], c
lobbers: [], volatile: true, alignstack: false, dialect: Att } : [] : [(/home/vext01/research/yorick/ykru
stc/src/libcore/hint.rs:116:25: 116:31, move _2)])
  $0 = $1                      
  $5 = $3
  $6 = $2                                                                                               
  $4 = lt($5, $6)
  $7 = $1           
  $8 = checked_add($3, $7)
  $3 = ($8).(unimplemented projection: "Field(field[0], usize)")                                        
  $5 = $3
  $6 = $2                                                                                               
  $4 = lt($5, $6)
  $7 = $1                                     
  $8 = checked_add($3, $7)
  $3 = ($8).(unimplemented projection: "Field(field[0], usize)")
  $5 = $3
  $6 = $2
  $4 = lt($5, $6)
...
```