### PR TITLE
Compile calls

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -170,6 +170,9 @@ pub enum Statement {
     Assign(Place, Rvalue),
     /// A return instruction
     Return,
+    /// A call terminator forwarding arguments to the next block and storing the call result in the
+    /// destination local.
+    Call(CallOperand, Vec<Operand>, Option<Place>),
     /// Any unimplemented lowering maps to this variant.
     /// The string inside is the stringified MIR statement.
     Unimplemented(String),
@@ -181,6 +184,7 @@ impl Display for Statement {
             Statement::Nop => write!(f, "nop"),
             Statement::Assign(l, r) => write!(f, "{} = {}", l, r),
             Statement::Return => write!(f, "return"),
+            Statement::Call(op, args, dest) => write!(f, "call({:?}, {:?}, {:?})", op, args, dest),
             Statement::Unimplemented(mir_stmt) => write!(f, "unimplemented_stmt: {}", mir_stmt),
         }
     }

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -36,7 +36,7 @@ impl HWTMapper {
                     let start_addr = block.start_vaddr() - self.phdr_offset;
                     let end_addr = start_addr + block.len();
                     for (addr, (sym, bb_idx)) in labels {
-                        if *addr >= start_addr && *addr < end_addr {
+                        if *addr >= start_addr && *addr <= end_addr {
                             // found matching label
                             annotrace.push(SirLoc::new(sym.to_string(), *bb_idx));
                             break;


### PR DESCRIPTION
This PR adds function calls to `ykcompile`, allowing us to compile function calls, including arguments and return variables.

In order to not overwrite in-use registers during a function call, we currently store all registers on the stack before entering a called block. This is really dumb but gets us going until we add a better register allocator soon.