### PR TITLE
Add a wrapper around dlsym(3).

### DIFF
--- a/ykcompile/Cargo.toml
+++ b/ykcompile/Cargo.toml
@@ -13,6 +13,7 @@ ykpack = { path = "../ykpack" }
 dynasmrt = "0.6"
 dynasm = "0.6"
 hex = "0.4"
+libc = "0.2"
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
This needs to go in after https://github.com/softdevteam/ykrustc/pull/100.

This is the first stage in being able to call symbols from within traces. The tests show that we can get the virtual addresses of things at runtime.