### PR TITLE
Avoid using hashmaps for SSA conversion

### DIFF
--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -72,6 +72,7 @@ mod tests {
             symbol_name: String::from("symbol1"),
             blocks: blocks1,
             flags: 0,
+            num_locals: 0,
         });
 
         let stmts2_b1 = vec![Statement::Nop; 7];
@@ -86,6 +87,7 @@ mod tests {
             symbol_name: String::from("symbol2"),
             blocks: blocks2,
             flags: 0,
+            num_locals: 0,
         });
 
         vec![sir1, sir2]
@@ -182,6 +184,7 @@ mod tests {
                 symbol_name: String::from("symbol1"),
                 blocks: blocks_t1,
                 flags: 0,
+                num_locals: 3,
             }),
             Pack::Body(Body {
                 symbol_name: String::from("symbol2"),
@@ -190,6 +193,7 @@ mod tests {
                     Terminator::Unreachable,
                 )],
                 flags: 0,
+                num_locals: 5,
             }),
         ];
 

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -124,6 +124,7 @@ pub struct Body {
     pub symbol_name: String,
     pub blocks: Vec<BasicBlock>,
     pub flags: u8,
+    pub num_locals: usize,
 }
 
 impl Display for Body {
@@ -169,7 +170,7 @@ pub enum Statement {
     /// An assignment.
     Assign(Place, Rvalue),
     /// Marks the entry of an inlined function call in a TIR trace. This does not appear in SIR.
-    Enter(CallOperand, Vec<Operand>, Option<Place>),
+    Enter(CallOperand, Vec<Operand>, Option<Place>, u32),
     /// Marks the exit of an inlined function call in a TIR trace. This does not appear in SIR.
     Leave,
     /// Information about which locals are currently live/dead.
@@ -188,8 +189,8 @@ impl Display for Statement {
         match self {
             Statement::Nop => write!(f, "nop"),
             Statement::Assign(l, r) => write!(f, "{} = {}", l, r),
-            Statement::Enter(op, args, dest) => {
-                write!(f, "enter({:?}, {:?}, {:?})", op, args, dest)
+            Statement::Enter(op, args, dest, off) => {
+                write!(f, "enter({:?}, {:?}, {:?}, {})", op, args, dest, off)
             }
             Statement::Leave => write!(f, "leave"),
             Statement::StorageLive(local) => write!(f, "StorageLive({:?})", local),


### PR DESCRIPTION
This PR updates the current SSA renaming approach to use a single vector instead of hashmaps of vectors. Before doing this we first remove any remnants of `start_tracing` and `stop_tracing` from the headers (772c560). We then move the existing SSA renaming code into its own struct (5ab2645) to make our life a bit easier. Finally, we update the SSA algorithm to use a vector instead of a hashamp (see commit message for more details).

This PR depends on https://github.com/softdevteam/ykrustc/pull/103.