### PR TITLE
Implement register spilling.

### DIFF
--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -173,12 +173,12 @@ impl TirTrace {
 
                     if let Some(callee_sym) = op.symbol() {
                         // We know the symbol name of the callee at least.
+                        // Rename all `Local`s within the arguments.
+                        let newargs = rnm.rename_args(&args);
                         let op = if let Some(callbody) = SIR.bodies.get(callee_sym) {
                             // We have SIR for the callee, so it will appear inlined in the trace
                             // and we only need to emit Enter/Leave statements.
 
-                            // Rename all `Local`s within the arguments.
-                            let newargs = rnm.rename_args(&args);
                             // Inform VarRenamer about this function's offset, which is equal to the
                             // number of variables assigned in the outer body.
                             rnm.enter(callbody.num_locals, ret_val.clone());
@@ -192,11 +192,7 @@ impl TirTrace {
                             // We have a symbol name but no SIR. Without SIR the callee can't
                             // appear inlined in the trace, so we should emit a native call to the
                             // symbol instead.
-                            TirOp::Statement(Statement::Call(
-                                op.clone(),
-                                args.to_vec(),
-                                Some(ret_val)
-                            ))
+                            TirOp::Statement(Statement::Call(op.clone(), newargs, Some(ret_val)))
                         };
                         ops.push(op);
                     } else {


### PR DESCRIPTION
This PR implements a new register allocator which means we won't have to crash anymore when we run out of registers. Note, that while our target algorithm, Bottom-Up Allocator [1], compiles traces from the bottom up, we will continue to compile things from the top, due to current restrictions in Dynasm.

This PR ended up a bit bigger than expected, but all changes should be split up nicely in separate commits that all make sense on their own.

e2196fb prepares the code for a new allocation algorithm by renaming a few variables.
c28a081 adds an `enum` which will hold the locations (e.g. stack/register) of locals.
4beb035 implements some basic register spilling.
570d791 adds some more spilling operations.
71947c5 makes sure that we only allocate as much space on the stack as is needed to hold the spilled locals.
ba58a55 implements spilling operations related to external calls.
b992e31 implements moving/spilling `u64` immediates to the stack, which isn't allowed by x86.

[1] https://dl.acm.org/doi/pdf/10.1145/3132190.3132209