### PR TITLE
Implement Display for SirTrace.

### DIFF
--- a/yktrace/src/debug.rs
+++ b/yktrace/src/debug.rs
@@ -1,38 +1,44 @@
 //! Debugging utilities.
 
 use crate::{tir::SIR, SirLoc, SirTrace};
-use std::{convert::TryFrom, iter::IntoIterator};
+use std::{convert::TryFrom, fmt::Write, iter::IntoIterator, string::String};
 pub use ykpack::{bodyflags, Statement};
 
 /// Prints a SIR trace to stdout for debugging purposes.
-pub fn print_sir_trace(trace: &dyn SirTrace, trimmed: bool, show_blocks: bool) {
+pub fn sir_trace_str<'a>(trace: &'a dyn SirTrace, trimmed: bool, show_blocks: bool) -> String {
     let locs: Vec<&SirLoc> = match trimmed {
         false => (0..(trace.raw_len())).map(|i| trace.raw_loc(i)).collect(),
         true => trace.into_iter().collect()
     };
 
-    println!("---[ BEGIN SIR TRACE DUMP ]---");
+    let mut res = String::new();
+    let res_r = &mut res;
     for loc in locs {
-        print!("[{}] bb={}, flags=[", loc.symbol_name, loc.bb_idx,);
+        write!(res_r, "[{}] bb={}, flags=[", loc.symbol_name, loc.bb_idx).unwrap();
 
         let body = SIR.bodies.get(&loc.symbol_name);
         if let Some(body) = body {
             if body.flags & bodyflags::TRACE_HEAD != 0 {
-                print!("HEAD ");
+                write!(res_r, "HEAD ").unwrap();
             }
             if body.flags & bodyflags::TRACE_TAIL != 0 {
-                print!("TAIL ");
+                write!(res_r, "TAIL ").unwrap();
             }
         }
-        println!("]");
+        writeln!(res_r, "]").unwrap();
 
         if show_blocks {
             if let Some(body) = body {
-                println!("{}:", body.blocks[usize::try_from(loc.bb_idx).unwrap()]);
+                writeln!(
+                    res_r,
+                    "{}:",
+                    body.blocks[usize::try_from(loc.bb_idx).unwrap()]
+                )
+                .unwrap();
             } else {
-                println!("    <no sir>");
+                writeln!(res_r, "    <no sir>").unwrap();
             }
         }
     }
-    println!("---[ END SIR TRACE DUMP ]---");
+    res
 }

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -16,6 +16,7 @@ mod hwt;
 pub mod tir;
 
 use errors::InvalidTraceError;
+use std::fmt::{self, Display};
 use tir::SIR;
 
 /// The same as core::SirLoc, just with a String representation of the symbol name and with the
@@ -59,6 +60,12 @@ impl<'a> IntoIterator for &'a dyn SirTrace {
 
     fn into_iter(self) -> Self::IntoIter {
         SirTraceIterator::new(self)
+    }
+}
+
+impl Display for dyn SirTrace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", debug::sir_trace_str(self, true, true))
     }
 }
 


### PR DESCRIPTION
This makes it easier to see the textual representation of sir.

Before we had to do:

```
use debug::print_sir_trace;
print_sir_trace(&*trace, true, true);
```