### PR TITLE
Use FM for TIR tests.

### DIFF
--- a/ykcompile/Cargo.toml
+++ b/ykcompile/Cargo.toml
@@ -14,6 +14,8 @@ dynasmrt = "0.6"
 dynasm = "0.6"
 hex = "0.4"
 libc = "0.2"
+fm = { git = "https://github.com/softdevteam/fm", rev = "12dcee1ee75f625942ffa889ef4d4e1fcf850832" }
+regex = "1"
 
 [build-dependencies]
 cc = "1.0"

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -216,7 +216,7 @@ impl Display for Statement {
                 } else {
                     String::from("none")
                 };
-                write!(f, "call({}, [{}], {})", op, args_s, dest_s)
+                write!(f, "{} = call({}, [{}])", dest_s, op, args_s)
             }
             Statement::Unimplemented(mir_stmt) => write!(f, "unimplemented_stmt: {}", mir_stmt),
         }


### PR DESCRIPTION
Now we can use our hard work on `fm` in `yk` :)

See commit messages for details.