### PR TITLE
Fix tests in the wake of a ykrustc upstream sync.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,6 +2,24 @@
 
 set -e
 
+# Rather than use the rustfmt from ykrustc, we use the last nightly snapshot
+# where rustfmt worked. It's often busted for days at a time, and we don't want
+# that to stall our development.
+#
+# We use a trick to guarantee we get a rustfmt from rustup:
+# https://github.com/rust-lang/rustup/issues/2227#issuecomment-584754687
+export CARGO_HOME="`pwd`/.cargo"
+export RUSTUP_HOME="`pwd`/.rustup"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain none -y --no-modify-path
+OLDPATH=${PATH}
+export PATH=${CARGO_HOME}/bin/:${RUSTUP_HOME}/bin:$PATH
+rustup toolchain install nightly
+cargo fmt --all -- --check
+export PATH=${OLDPATH}
+unset CARGO_HOME
+unset RUSTUP_HOME
+
 case ${STD_TRACER_MODE} in
     "sw") export RUSTFLAGS="-C tracer=sw";;
     "hw") export RUSTFLAGS="-C tracer=hw";;
@@ -13,7 +31,6 @@ esac
 tar jxf /opt/ykrustc-bin-snapshots/ykrustc-${STD_TRACER_MODE}-stage2-latest.tar.bz2
 export PATH=`pwd`/ykrustc-stage2-latest/bin:${PATH}
 
-cargo fmt --all -- --check
 cargo test
 
 # Although it might be tempting to test release mode, we have (for now) made

--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -950,6 +950,7 @@ mod tests {
         let _d = 4;
         let _e = 5;
         let _f = 6;
+        let _g = 7;
         let h: u64 = u64value();
         h
     }
@@ -973,6 +974,7 @@ mod tests {
         let _d = 4;
         let _e = 5;
         let _f = 6;
+        let _g = 7;
         let h = arg;
         h
     }


### PR DESCRIPTION
The Rust compiler now emits one fewer local sometimes, and this broke our spill tests.

This should go in after the upstream sync PR.