### PR TITLE
Compile references and dereferences.

### DIFF
--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -341,6 +341,10 @@ impl VarRenamer {
                 let newop2 = self.rename_operand(op2);
                 Rvalue::CheckedBinaryOp(binop.clone(), newop1, newop2)
             }
+            Rvalue::Ref(place) => {
+                let newplace = self.rename_place(place);
+                Rvalue::Ref(newplace)
+            }
             Rvalue::Unimplemented(_) => rvalue.clone()
         }
     }


### PR DESCRIPTION
I've left a few `todo`'s in the code to try and keep this PR small. We won't be needing them right now so we can implement them at a later stage.