### PR TITLE
Assembly helpers.

### DIFF
--- a/ykcompile/src/asm_helpers.rs
+++ b/ykcompile/src/asm_helpers.rs
@@ -1,0 +1,30 @@
+//! Helpers for generating assembler code with dynasm.
+
+/// Emits a 'mem <- reg'  assembler instruction using the desired size qualifier.
+macro_rules! asm_mem_reg {
+    ($dasm: expr, $size: expr, $op: expr, $mem: expr, $reg: expr) => {
+        match $size {
+            1 => {
+                dynasm!($dasm
+                    ; $op BYTE $mem, Rb($reg)
+                );
+            }
+            2 => {
+                dynasm!($dasm
+                    ; $op WORD $mem, Rw($reg)
+                );
+            },
+            4 => {
+                dynasm!($dasm
+                    ; $op DWORD $mem, Rd($reg)
+                );
+            },
+            8 => {
+                dynasm!($dasm
+                    ; $op QWORD $mem, Rq($reg)
+                );
+            }
+            _ => panic!("Invalid size operand: {}", $size),
+        }
+    }
+}


### PR DESCRIPTION
@ptersilie, here's a draft of the assembler helpers work.

 - `asm_mem_reg!` emits an assembler instruction of your choosing (`mov`, `add`, ...) using the right size qualifier. Eventually we can ask SIR for the size of a type (but not just yet).
 - If this looks good I'll add a `asm_reg_mem!` too.
 - It's not clear if it's necessary for a `asm_reg_reg!`. Wouldn't `mov eax, ebx` do the same as `mov rax, rbx`?

Tests pass.

Raising as a draft to check I've not overlooked anything. Does this look usable?

Thanks to @CensoredUsername for helping with macro details. Please feel free to comment :)