### PR TITLE
Add viewer for the SIR in executables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members=[
     "yktrace",
     # Disabled for now to focus on code-gen.
     #"tiri",
-    "ykcompile"
+    "ykcompile",
+    "ykview",
 ]
 
 [profile.dev]

--- a/yktrace/src/sir.rs
+++ b/yktrace/src/sir.rs
@@ -8,7 +8,8 @@ use std::{
     env,
     fmt::{self, Debug, Display, Write},
     io::Cursor,
-    iter::Iterator
+    iter::Iterator,
+    path::Path
 };
 use ykpack::{bodyflags, Body, Decoder, Local, Pack, Ty}; // FIXME kill.
 
@@ -56,8 +57,12 @@ pub struct SirMarkers {
 }
 
 lazy_static! {
-    pub static ref SIR: Sir = {
-        let ef = elf::File::open_path(env::current_exe().unwrap()).unwrap();
+    pub static ref SIR: Sir = { Sir::read_file(&env::current_exe().unwrap()).unwrap() };
+}
+
+impl Sir {
+    pub fn read_file(file: &Path) -> Result<Sir, ()> {
+        let ef = elf::File::open_path(file).unwrap();
 
         // We iterate over ELF sections, looking for ones which contain SIR and loading it into
         // memory.
@@ -87,15 +92,17 @@ lazy_static! {
                             // duplicates exist, the functions will be identical, but may have
                             // different (but equivalent) types. This is because types too may be
                             // duplicated using a different crate hash.
-                            bodies.entry(body.symbol_name.clone()).or_insert_with(|| body);
-                        },
+                            bodies
+                                .entry(body.symbol_name.clone())
+                                .or_insert_with(|| body);
+                        }
                         Pack::Types(ts) => {
                             let old = types.insert(ts.crate_hash, ts.types);
                             debug_assert!(old.is_none()); // There's one `Types` pack per crate.
                             for idx in ts.thread_tracers {
                                 thread_tracers.insert((ts.crate_hash, idx));
                             }
-                        },
+                        }
                     }
                 }
             }
@@ -103,10 +110,18 @@ lazy_static! {
 
         assert!(!trace_heads.is_empty(), "no trace heads found!");
         assert!(!trace_tails.is_empty(), "no trace tails found!");
-        let markers = SirMarkers { trace_heads, trace_tails };
+        let markers = SirMarkers {
+            trace_heads,
+            trace_tails
+        };
 
-        Sir {bodies, markers, types, thread_tracers}
-    };
+        Ok(Sir {
+            bodies,
+            markers,
+            types,
+            thread_tracers
+        })
+    }
 }
 
 /// The same as core::SirLoc, just with a String representation of the symbol name and with the
@@ -146,12 +161,12 @@ impl<'a> IntoIterator for &'a dyn SirTrace {
     type IntoIter = SirTraceIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        SirTraceIterator::new(self)
+        SirTraceIterator::new(&*SIR, self)
     }
 }
 
 /// Returns a string containing the textual representation of a SIR trace.
-pub fn sir_trace_str<'a>(trace: &'a dyn SirTrace, trimmed: bool, show_blocks: bool) -> String {
+pub fn sir_trace_str(sir: &Sir, trace: &dyn SirTrace, trimmed: bool, show_blocks: bool) -> String {
     let locs: Vec<&SirLoc> = match trimmed {
         false => (0..(trace.raw_len())).map(|i| trace.raw_loc(i)).collect(),
         true => trace.into_iter().collect()
@@ -164,7 +179,7 @@ pub fn sir_trace_str<'a>(trace: &'a dyn SirTrace, trimmed: bool, show_blocks: bo
     for loc in locs {
         write!(res_r, "[{}] bb={}, flags=[", loc.symbol_name, loc.bb_idx).unwrap();
 
-        let body = SIR.bodies.get(&loc.symbol_name);
+        let body = sir.bodies.get(&loc.symbol_name);
         if let Some(body) = body {
             if body.flags & bodyflags::TRACE_HEAD != 0 {
                 write!(res_r, "HEAD ").unwrap();
@@ -193,30 +208,32 @@ pub fn sir_trace_str<'a>(trace: &'a dyn SirTrace, trimmed: bool, show_blocks: bo
 
 impl Display for dyn SirTrace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", sir_trace_str(self, true, true))
+        write!(f, "{}", sir_trace_str(&*SIR, self, false, true))
     }
 }
 
 /// An iterator over a trimmed SIR trace.
 pub struct SirTraceIterator<'a> {
+    sir: &'a Sir,
     trace: &'a dyn SirTrace,
     next_idx: usize
 }
 
 impl<'a> SirTraceIterator<'a> {
-    fn new(trace: &'a dyn SirTrace) -> Self {
+    pub fn new(sir: &'a Sir, trace: &'a dyn SirTrace) -> Self {
         // We are going to present a "trimmed trace", so we do a backwards scan looking for the end
         // of the code that starts the tracer.
         let mut begin_idx = None;
         for blk_idx in (0..trace.raw_len()).rev() {
             let sym = &trace.raw_loc(blk_idx).symbol_name;
-            if SIR.markers.trace_heads.contains(sym) {
+            if sir.markers.trace_heads.contains(sym) {
                 begin_idx = Some(blk_idx + 1);
                 break;
             }
         }
 
         SirTraceIterator {
+            sir,
             trace,
             next_idx: begin_idx.expect("Couldn't find the end of the code that starts the tracer")
         }
@@ -229,7 +246,7 @@ impl<'a> Iterator for SirTraceIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.next_idx < self.trace.raw_len() {
             let sym = &self.trace.raw_loc(self.next_idx).symbol_name;
-            if SIR.markers.trace_tails.contains(sym) {
+            if self.sir.markers.trace_tails.contains(sym) {
                 // Stop when we find the start of the code that stops the tracer, thus trimming the
                 // end of the trace. By setting the next index to one above the last one in the
                 // trace, we ensure the iterator will return `None` forever more.

--- a/yktrace/src/sir.rs
+++ b/yktrace/src/sir.rs
@@ -124,6 +124,35 @@ impl Sir {
     }
 }
 
+impl Display for Sir {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for body in self.bodies.values() {
+            writeln!(f, "{}", body)?;
+        }
+
+        for head in &self.markers.trace_heads {
+            writeln!(f, "HEAD {}", head)?;
+        }
+
+        for tail in &self.markers.trace_tails {
+            writeln!(f, "TAIL {}", tail)?;
+        }
+
+        for (crate_hash, types) in self.types.iter() {
+            writeln!(f, "TYPES OF {}", crate_hash)?;
+            for ty in types {
+                writeln!(f, "{}", ty)?;
+            }
+        }
+
+        for thread_tracer in self.thread_tracers.iter() {
+            writeln!(f, "THREAD TRACER {}:{}", thread_tracer.0, thread_tracer.1)?;
+        }
+
+        Ok(())
+    }
+}
+
 /// The same as core::SirLoc, just with a String representation of the symbol name and with the
 /// traits we were disallowed from using in libcore.
 #[derive(Debug, Hash, Eq, PartialEq)]

--- a/yktrace/src/sir.rs
+++ b/yktrace/src/sir.rs
@@ -15,6 +15,7 @@ use ykpack::{bodyflags, Body, Decoder, Local, Pack, Ty}; // FIXME kill.
 
 /// The serialised IR loaded in from disk. One of these structures is generated in the above
 /// `lazy_static` and is shared immutably for all threads.
+#[derive(Debug)]
 pub struct Sir {
     /// Lets us map a symbol name to a SIR body.
     pub bodies: HashMap<String, Body>,
@@ -37,6 +38,7 @@ impl Sir {
 }
 
 /// Records interesting locations required for trace manipulation.
+#[derive(Debug)]
 pub struct SirMarkers {
     /// Functions which start tracing and whose suffix gets trimmed off the top of traces.
     /// Although you'd expect only one such function, (i.e. `yktrace::start_tracing`), in fact

--- a/ykview/Cargo.toml
+++ b/ykview/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ykview"
+version = "0.1.0"
+authors = ["bjorn3 <bjorn3@users.noreply.github.com>"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+ykpack = { path = "../ykpack" }
+yktrace = { path = "../yktrace" }

--- a/ykview/src/main.rs
+++ b/ykview/src/main.rs
@@ -1,0 +1,65 @@
+use std::io::Read;
+
+fn main() {
+    let mut args = std::env::args();
+    args.next().unwrap(); // command name
+    let sir = if let Some(file) = args.next() {
+        yktrace::sir::Sir::read_file(file.as_ref()).unwrap()
+    } else {
+        println!(
+            "No executable provided\n\
+            Usage: ykview <executable> [<trace file>]\n\
+            \n\
+            Trace format:\n\
+            symbol_name1 bb_index1\n\
+            symbol_name2 bb_index2\n\
+            ..."
+        );
+        std::process::exit(1);
+    };
+
+    if let Some(trace_file) = args.next() {
+        let trace_text = if trace_file == "-" {
+            let mut trace = Vec::new();
+            std::io::stdin().read_to_end(&mut trace).unwrap();
+            trace
+        } else {
+            std::fs::read(trace_file).unwrap()
+        };
+        let trace_text = String::from_utf8(trace_text).unwrap();
+        let mut trace = VecSirTrace(vec![]);
+        for line in trace_text.lines() {
+            let mut parts = line.trim().split(" ");
+            let symbol_name = parts.next().unwrap().to_string();
+            let bb_idx = parts.next().unwrap().parse::<u32>().unwrap();
+            assert!(parts.next().is_none());
+            trace.0.push(yktrace::sir::SirLoc {
+                symbol_name,
+                bb_idx,
+                addr: None,
+            });
+        }
+        for loc in yktrace::sir::SirTraceIterator::new(&sir, &trace) {
+            println!("{:?}", loc);
+        }
+    } else {
+        println!("{}", sir);
+    }
+}
+
+#[derive(Debug)]
+struct VecSirTrace(Vec<yktrace::sir::SirLoc>);
+
+impl yktrace::sir::SirTrace for VecSirTrace {
+    fn raw_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn raw_loc(&self, idx: usize) -> &yktrace::sir::SirLoc {
+        &self.0[idx]
+    }
+
+    fn input(&self) -> ykpack::Local {
+        todo!()
+    }
+}

--- a/ykview/src/main.rs
+++ b/ykview/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
             std::fs::read(trace_file).unwrap()
         };
         let trace_text = String::from_utf8(trace_text).unwrap();
-        let mut trace = VecSirTrace(vec![]);
+        let mut trace = VecSirTrace(vec![], ykpack::Local(0) /*FIXME*/);
         for line in trace_text.lines() {
             let mut parts = line.trim().split(" ");
             let symbol_name = parts.next().unwrap().to_string();
@@ -42,13 +42,15 @@ fn main() {
         for loc in yktrace::sir::SirTraceIterator::new(&sir, &trace) {
             println!("{:?}", loc);
         }
+        let tir = yktrace::tir::TirTrace::new(&sir, &trace).unwrap();
+        println!("{}", tir);
     } else {
         println!("{}", sir);
     }
 }
 
 #[derive(Debug)]
-struct VecSirTrace(Vec<yktrace::sir::SirLoc>);
+struct VecSirTrace(Vec<yktrace::sir::SirLoc>, ykpack::Local);
 
 impl yktrace::sir::SirTrace for VecSirTrace {
     fn raw_len(&self) -> usize {
@@ -60,6 +62,6 @@ impl yktrace::sir::SirTrace for VecSirTrace {
     }
 
     fn input(&self) -> ykpack::Local {
-        todo!()
+        self.1
     }
 }


### PR DESCRIPTION
This can be useful while debugging.

I have also added a way to generate and show TIR for a trace specified in a format like:

```
_ZN21mini_core_hello_world20yk_swt_start_tracing17hd35172730ed8f9e0E 2
_ZN21mini_core_hello_world5start17hc857f9701ee10e6bE 2
_ZN21mini_core_hello_world5start17hc857f9701ee10e6bE 4
_ZN21mini_core_hello_world5start17hc857f9701ee10e6bE 5
_ZN21mini_core_hello_world4main17h4614255fce60abb6E 1
_ZN21mini_core_hello_world8take_f3217h7c2802eb13dcfab7E 1
_ZN21mini_core_hello_world4main17h4614255fce60abb6E 2
_ZN21mini_core_hello_world5start17hc857f9701ee10e6bE 6
_ZN63_$LT$$LP$$RP$$u20$as$u20$mini_core_hello_world..Termination$GT$6report17hcfb2e8675d965aaeE 1
_ZN21mini_core_hello_world5start17hc857f9701ee10e6bE 7
_ZN21mini_core_hello_world19yk_swt_stop_tracing17h5af4cd5c43ee1fdeE 1
```

I have not been able to test that functionality yet, as cg_clif currently doesn't generate enough sir for it to work without errors.