### PR TITLE
Try to remove unused definitions.

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -520,6 +520,14 @@ impl Statement {
         }
         ret
     }
+
+    /// Returns true if the statement may affect locals besides those appearing in the statement.
+    pub fn may_have_side_effects(&self) -> bool {
+        match self {
+            Statement::Call(..) | Statement::Enter(..) => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for Statement {


### PR DESCRIPTION
This is not perfect. It works well for simple locals, but consider `x.0 = 0; x.1 = 1` and then x is not used after. The first operation will be seen to define `x`, the second will be seen as a use of `x`, and thus neither of these statements will be removed.

Still, it's better than nothing.