### PR TITLE
New trimming scheme for yk

### DIFF
--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -356,7 +356,7 @@ impl<TT> TraceCompiler<TT> {
                                 ; add Rq(temp), [Rq(ro.reg) + ro.offs]
                             );
                         }
-                        Location::Register(reg) => todo!(),
+                        Location::Register(_) => todo!(),
                         Location::Addr(reg) => {
                             dynasm!(self.asm
                                 ; add Rq(temp), Rq(reg)
@@ -423,9 +423,7 @@ impl<TT> TraceCompiler<TT> {
     /// performs one.
     fn local_to_location(&mut self, l: Local) -> Location {
         if l == INTERP_STEP_ARG {
-            // If the local references `trace_inputs` return its location on the stack, which is
-            // stored in the first argument of the executed trace.
-            Location::Register(RDI.code())
+            Location::Register(RDI.code()) // i.e. the first arg register.
         } else if let Some(location) = self.variable_location_map.get(&l) {
             // We already have a location for this local.
             location.clone()
@@ -1290,7 +1288,7 @@ mod tests {
     use std::marker::PhantomData;
     use yktrace::sir::SIR;
     use yktrace::tir::TirTrace;
-    use yktrace::{start_tracing, trace_inputs, TracingKind};
+    use yktrace::{start_tracing, TracingKind};
 
     extern "C" {
         fn add6(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64;
@@ -1953,7 +1951,7 @@ mod tests {
         }
 
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
         interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();

--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -22,11 +22,11 @@ use std::fmt::{self, Display, Formatter};
 use std::mem;
 use std::process::Command;
 use ykpack::{SignedIntTy, Ty, TypeId, UnsignedIntTy};
-use yktrace::sir::SIR;
 use yktrace::tir::{
     BinOp, CallOperand, Constant, ConstantInt, Guard, Local, Operand, Place, Projection, Rvalue,
     Statement, TirOp, TirTrace,
 };
+use yktrace::{sir::SIR, INTERP_STEP_ARG};
 
 use dynasmrt::{DynasmApi, DynasmLabelApi};
 
@@ -37,8 +37,8 @@ lazy_static! {
 
     // Register partitioning. These arrays must not overlap.
     // FIXME add callee save registers to the pool. Trace code will need to save/restore them.
-    static ref TEMP_REGS: [u8; 2] = [R10.code(), R11.code()];
-    static ref LOCAL_REGS: [u8; 4] = [R9.code(), R8.code(), RDX.code(), RCX.code()];
+    static ref TEMP_REGS: [u8; 3] = [R9.code(), R10.code(), R11.code()];
+    static ref LOCAL_REGS: [u8; 3] = [R8.code(), RDX.code(), RCX.code()];
 }
 
 fn is_temp_reg(reg: u8) -> bool {
@@ -169,8 +169,6 @@ pub struct TraceCompiler<TT> {
     variable_location_map: HashMap<Local, Location>,
     /// Available temproary registers.
     temp_regs: Vec<u8>,
-    /// Local referencing the input arguments to the trace.
-    trace_inputs_local: Option<Local>,
     /// Local decls of the tir trace.
     local_decls: HashMap<Local, LocalDecl>,
     /// Stack builder for allocating objects on the stack.
@@ -241,61 +239,19 @@ impl<TT> TraceCompiler<TT> {
         while let Some(proj) = iter.next() {
             match proj {
                 Projection::Field(idx) => match ty {
-                    Ty::Struct(sty) => match curloc {
-                        Location::Mem(ro) => {
-                            let offs = sty.fields.offsets[usize::try_from(*idx).unwrap()];
-                            ty = SIR
-                                .ty(&sty.fields.tys[usize::try_from(*idx).unwrap()])
-                                .clone();
-                            curloc =
-                                Location::new_mem(ro.reg, ro.offs + i32::try_from(offs).unwrap());
-                        }
-                        _ => unreachable!("{:?}", curloc),
-                    },
-                    Ty::Tuple(tty) => match curloc {
-                        Location::Mem(ro) => {
-                            let offs = tty.fields.offsets[usize::try_from(*idx).unwrap()];
-                            ty = SIR
-                                .ty(&tty.fields.tys[usize::try_from(*idx).unwrap()])
-                                .clone();
-                            curloc =
-                                Location::new_mem(ro.reg, ro.offs + i32::try_from(offs).unwrap());
-                        }
-                        _ => unreachable!("{:?}", curloc),
-                    },
-                    Ty::Ref(tyid) => match SIR.ty(&tyid) {
-                        Ty::Struct(sty) => {
-                            let offs = sty.fields.offsets[usize::try_from(*idx).unwrap()];
-                            ty = SIR
-                                .ty(&sty.fields.tys[usize::try_from(*idx).unwrap()])
-                                .clone();
-                            let temp = self.create_temporary();
-                            match &curloc {
-                                Location::Mem(ro) => {
-                                    dynasm!(self.asm
-                                        ; lea Rq(temp), [Rq(ro.reg) + ro.offs + i32::try_from(offs).unwrap()]
-                                    );
-                                }
-                                Location::Register(reg) => {
-                                    dynasm!(self.asm
-                                        ; lea Rq(temp), [Rq(reg) + i32::try_from(offs).unwrap()]
-                                    );
-                                }
-                                _ => unreachable!(),
-                            }
-                            self.free_if_temp(curloc);
-                            curloc = if store {
-                                Location::Addr(temp)
-                            } else {
-                                dynasm!(self.asm
-                                    ; mov Rq(temp), [Rq(temp)]
-                                );
-                                Location::Register(temp)
-                            };
-                        }
-                        Ty::Tuple(_tty) => todo!(),
-                        _ => unreachable!(),
-                    },
+                    Ty::Struct(ref sty) => {
+                        let offs = sty.fields.offsets[usize::try_from(*idx).unwrap()];
+                        let ftyid = &sty.fields.tys[usize::try_from(*idx).unwrap()];
+                        curloc = self.resolve_field(curloc, ftyid, offs, store);
+                        ty = SIR.ty(ftyid).clone();
+                    }
+                    Ty::Tuple(ref tty) => {
+                        let offs = tty.fields.offsets[usize::try_from(*idx).unwrap()];
+                        let ftyid = &tty.fields.tys[usize::try_from(*idx).unwrap()];
+                        curloc = self.resolve_field(curloc, ftyid, offs, store);
+                        ty = SIR.ty(ftyid).clone();
+                    }
+                    Ty::Ref(_) => unreachable!("ref"),
                     _ => todo!("{:?}", ty),
                 },
                 Projection::Deref => {
@@ -346,17 +302,32 @@ impl<TT> TraceCompiler<TT> {
                             Location::Register(temp)
                         };
                         ty = SIR.ty(&tyid).clone();
+                    } else {
+                        // Dereferencing a pointer, where the pointee is uncopyable, converts the
+                        // location to an address.
+                        let temp = self.create_temporary();
+                        ty = SIR.ty(&tyid).clone(); // FIXME dedup
+                        match &curloc {
+                            Location::Mem(ro) => {
+                                dynasm!(self.asm
+                                    ; mov Rq(temp), [Rq(ro.reg) + ro.offs]
+                                );
+                            }
+                            Location::Register(reg) | Location::Addr(reg) => {
+                                dynasm!(self.asm
+                                    ; mov Rq(temp), Rq(reg)
+                                );
+                            }
+                            _ => unreachable!(),
+                        }
+                        self.free_if_temp(curloc);
+                        curloc = Location::Addr(temp);
                     }
                 }
                 Projection::Index(local) => {
                     // Get the type of the array elements.
                     let elem_ty = match ty {
-                        Ty::Array(_) => {
-                            // FIXME Since we can't compile array construction yet, we can assume
-                            // we are always dealing with references here. Once we can, the
-                            // assembler instructions below also need updating.
-                            todo!()
-                        }
+                        Ty::Array(ety) => SIR.ty(&ety),
                         Ty::Ref(tyid) => match SIR.ty(&tyid) {
                             Ty::Array(ety) => SIR.ty(&ety),
                             _ => unreachable!(),
@@ -385,7 +356,8 @@ impl<TT> TraceCompiler<TT> {
                                 ; add Rq(temp), [Rq(ro.reg) + ro.offs]
                             );
                         }
-                        Location::Register(reg) => {
+                        Location::Register(reg) => todo!(),
+                        Location::Addr(reg) => {
                             dynasm!(self.asm
                                 ; add Rq(temp), Rq(reg)
                             );
@@ -409,13 +381,51 @@ impl<TT> TraceCompiler<TT> {
         (curloc, ty)
     }
 
+    fn resolve_field(&mut self, loc: Location, tyid: &TypeId, offs: u64, store: bool) -> Location {
+        // Convert Mem into Addr.
+        let temp = self.create_temporary();
+        match &loc {
+            Location::Mem(ro) => {
+                dynasm!(self.asm
+                    ; lea Rq(temp), [Rq(ro.reg) + ro.offs]
+                );
+            }
+            Location::Register(reg) | Location::Addr(reg) => {
+                dynasm!(self.asm
+                    ; mov Rq(temp), Rq(reg)
+                );
+            }
+            _ => unreachable!("{:?}", loc),
+        };
+        self.free_if_temp(loc);
+
+        // Get index.
+        dynasm!(self.asm
+            ; lea Rq(temp), [Rq(temp) + i32::try_from(offs).unwrap()]
+        );
+
+        if store {
+            return Location::Addr(temp);
+        }
+        if Self::can_live_in_register(tyid) {
+            dynasm!(self.asm
+                ; mov Rq(temp), [Rq(temp)]
+            );
+            Location::Register(temp)
+        } else if Self::is_copyable(tyid) {
+            todo!()
+        } else {
+            Location::Addr(temp)
+        }
+    }
+
     /// Given a local, returns the register allocation for it, or, if there is no allocation yet,
     /// performs one.
     fn local_to_location(&mut self, l: Local) -> Location {
-        if Some(l) == self.trace_inputs_local {
+        if l == INTERP_STEP_ARG {
             // If the local references `trace_inputs` return its location on the stack, which is
             // stored in the first argument of the executed trace.
-            Location::new_mem(RDI.code(), 0 as i32)
+            Location::Register(RDI.code())
         } else if let Some(location) = self.variable_location_map.get(&l) {
             // We already have a location for this local.
             location.clone()
@@ -799,7 +809,36 @@ impl<TT> TraceCompiler<TT> {
     fn c_checked_binop(&mut self, binop: &BinOp, op1: &Operand, op2: &Operand) -> Location {
         // Move `op1` into `dest`.
         let dest_loc = match op1 {
-            Operand::Place(p) => self.c_place(&p),
+            Operand::Place(p) => match self.place_to_location(p, false) {
+                (Location::Mem(ro), ty) => {
+                    let tmp = self.create_temporary();
+                    match ty.size() {
+                        1 => {
+                            dynasm!(self.asm
+                                ; mov Rb(tmp), BYTE [Rq(ro.reg) + ro.offs]
+                            );
+                        }
+                        2 => {
+                            dynasm!(self.asm
+                                ; mov Rw(tmp), WORD [Rq(ro.reg) + ro.offs]
+                            );
+                        }
+                        4 => {
+                            dynasm!(self.asm
+                                ; mov Rd(tmp), DWORD [Rq(ro.reg) + ro.offs]
+                            );
+                        }
+                        8 => {
+                            dynasm!(self.asm
+                                ; mov Rq(tmp), QWORD [Rq(ro.reg) + ro.offs]
+                            );
+                        }
+                        _ => unreachable!(),
+                    }
+                    Location::Register(tmp)
+                }
+                (other, _) => other,
+            },
             Operand::Constant(Constant::Int(ci)) => self.c_constint(&ci),
             Operand::Constant(Constant::Bool(_b)) => unreachable!(),
             Operand::Constant(c) => todo!("{}", c),
@@ -1198,7 +1237,6 @@ impl<TT> TraceCompiler<TT> {
             temp_regs: Vec::from(*TEMP_REGS),
             register_content_map: LOCAL_REGS.iter().map(|r| (*r, RegAlloc::Free)).collect(),
             variable_location_map: HashMap::new(),
-            trace_inputs_local: tt.inputs().map(|t| t.clone()),
             local_decls: tt.local_decls.clone(),
             stack_builder: StackBuilder::default(),
             addr_map: tt.addr_map.drain().into_iter().collect(),
@@ -1257,6 +1295,9 @@ mod tests {
     extern "C" {
         fn add6(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64;
     }
+    extern "C" {
+        fn add_some(a: u64, b: u64, c: u64, d: u64, e: u64) -> u64;
+    }
 
     /// Fuzzy matches the textual TIR for the trace `tt` with the pattern `ptn`.
     fn assert_tir(ptn: &str, tt: &TirTrace) {
@@ -1276,18 +1317,19 @@ mod tests {
         }
     }
 
-    #[inline(never)]
-    fn simple() -> u8 {
-        let x = 13;
-        x
-    }
-
     #[test]
     fn test_simple() {
         struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[interp_step]
+        #[inline(never)]
+        fn simple(io: &mut IO) {
+            let x = 13;
+            io.0 = x;
+        }
+
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = simple();
+        simple(&mut IO(0));
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1311,7 +1353,6 @@ mod tests {
                 .collect(),
             temp_regs: Vec::from(*TEMP_REGS),
             variable_location_map: HashMap::new(),
-            trace_inputs_local: None,
             local_decls: HashMap::default(),
             stack_builder: StackBuilder::default(),
             addr_map: HashMap::new(),
@@ -1341,7 +1382,6 @@ mod tests {
                 .collect(),
             temp_regs: Vec::from(*TEMP_REGS),
             variable_location_map: HashMap::new(),
-            trace_inputs_local: None,
             local_decls,
             stack_builder: StackBuilder::default(),
             addr_map: HashMap::new(),
@@ -1361,19 +1401,20 @@ mod tests {
         i
     }
 
-    #[inline(never)]
-    fn fcall() -> u8 {
-        let y = farg(13); // assigns 13 to $1
-        let _z = farg(14); // overwrites $1 within the call
-        y // returns $1
-    }
-
     #[test]
     fn test_function_call_simple() {
         struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[interp_step]
+        #[inline(never)]
+        fn fcall(io: &mut IO) {
+            io.0 = farg(13);
+            let _z = farg(14);
+        }
+
+        let mut io = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = fcall();
+        fcall(&mut io);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1382,26 +1423,27 @@ mod tests {
         assert_eq!(args.0, 13);
     }
 
-    fn fnested3(i: u8, _j: u8) -> u8 {
-        let c = i;
-        c
-    }
-
-    fn fnested2(i: u8) -> u8 {
-        fnested3(i, 10)
-    }
-
-    fn fnested() -> u8 {
-        let a = fnested2(20);
-        a
-    }
-
     #[test]
     fn test_function_call_nested() {
         struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+
+        fn fnested3(i: u8, _j: u8) -> u8 {
+            let c = i;
+            c
+        }
+
+        fn fnested2(i: u8) -> u8 {
+            fnested3(i, 10)
+        }
+
+        #[interp_step]
+        fn fnested(io: &mut IO) {
+            io.0 = fnested2(20);
+        }
+
+        let mut io = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = fnested();
+        fnested(&mut io);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1444,8 +1486,14 @@ mod tests {
     // call operation.
     #[test]
     fn call_symbol_tir() {
+        struct IO(());
+        #[interp_step]
+        fn interp_step(_: &mut IO) {
+            let _ = unsafe { add6(1, 1, 1, 1, 1, 1) };
+        }
+
         let th = start_tracing(TracingKind::HardwareTracing);
-        let _ = unsafe { add6(1, 1, 1, 1, 1, 1) };
+        interp_step(&mut IO(()));
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         assert_tir(
@@ -1463,9 +1511,14 @@ mod tests {
     #[test]
     fn exec_call_symbol_no_args() {
         struct IO(u32);
-        let mut inputs = trace_inputs(IO(0));
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = unsafe { getuid() };
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = unsafe { getuid() };
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let mut args = IO(0);
@@ -1477,13 +1530,17 @@ mod tests {
     #[test]
     fn exec_call_symbol_with_arg() {
         struct IO(i32);
-        let mut inputs = trace_inputs(IO(0));
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = unsafe { abs(io.0) };
+        }
+
+        let mut inputs = IO(-56);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let v = -56;
-        inputs.0 = unsafe { abs(v) };
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
-        let mut args = IO(0);
+        let mut args = IO(-56);
         TraceCompiler::<IO>::compile(tir_trace).execute(&mut args);
         assert_eq!(inputs.0, args.0);
     }
@@ -1492,9 +1549,14 @@ mod tests {
     #[test]
     fn exec_call_symbol_with_const_arg() {
         struct IO(i32);
-        let mut inputs = trace_inputs(IO(0));
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = unsafe { abs(-123) };
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = unsafe { abs(-123) };
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let mut args = IO(0);
@@ -1505,9 +1567,14 @@ mod tests {
     #[test]
     fn exec_call_symbol_with_many_args() {
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = unsafe { add6(1, 2, 3, 4, 5, 6) };
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = unsafe { add6(1, 2, 3, 4, 5, 6) };
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let mut args = IO(0);
@@ -1518,14 +1585,15 @@ mod tests {
 
     #[test]
     fn exec_call_symbol_with_many_args_some_ignored() {
-        extern "C" {
-            fn add_some(a: u64, b: u64, c: u64, d: u64, e: u64) -> u64;
+        struct IO(u64);
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = unsafe { add_some(1, 2, 3, 4, 5) };
         }
 
-        struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = unsafe { add_some(1, 2, 3, 4, 5) };
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let mut args = IO(0);
@@ -1534,25 +1602,27 @@ mod tests {
         assert_eq!(args.0, inputs.0);
     }
 
-    fn many_locals() -> u8 {
-        let _a = 1;
-        let _b = 2;
-        let _c = 3;
-        let _d = 4;
-        let _e = 5;
-        let _f = 6;
-        let h = 7;
-        let _g = true;
-        h
-    }
-
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
     fn test_spilling_simple() {
-        struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+        struct IO(u64);
+
+        #[interp_step]
+        fn many_locals(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let _c = 3;
+            let _d = 4;
+            let _e = 5;
+            let _f = 6;
+            let h = 7;
+            let _g = true;
+            io.0 = h;
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = many_locals();
+        many_locals(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
@@ -1562,32 +1632,34 @@ mod tests {
         assert_eq!(spills, 3); // Three u8s.
     }
 
-    fn u64value() -> u64 {
-        // We need an extra function here to avoid SIR optimising this by assigning assigning the
-        // constant directly to the return value (which is a register).
-        4294967296 + 8
-    }
-
-    #[inline(never)]
-    fn spill_u64() -> u64 {
-        let _a = 1;
-        let _b = 2;
-        let _c = 3;
-        let _d = 4;
-        let _e = 5;
-        let _f = 6;
-        let _g = 7;
-        let h: u64 = u64value();
-        h
-    }
-
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
     fn test_spilling_u64() {
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+
+        fn u64value() -> u64 {
+            // We need an extra function here to avoid SIR optimising this by assigning assigning the
+            // constant directly to the return value (which is a register).
+            4294967296 + 8
+        }
+
+        #[inline(never)]
+        #[interp_step]
+        fn spill_u64(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let _c = 3;
+            let _d = 4;
+            let _e = 5;
+            let _f = 6;
+            let _g = 7;
+            let h: u64 = u64value();
+            io.0 = h;
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = spill_u64();
+        spill_u64(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
@@ -1597,54 +1669,58 @@ mod tests {
         assert_eq!(spills, 2 * 8);
     }
 
-    fn register_to_stack(arg: u8) -> u8 {
-        let _a = 1;
-        let _b = 2;
-        let _c = 3;
-        let _d = 4;
-        let _e = 5;
-        let _f = 6;
-        let _g = 7;
-        let h = arg;
-        h
-    }
-
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
     fn test_mov_register_to_stack() {
-        struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+        struct IO(u8, u8);
+
+        #[interp_step]
+        fn register_to_stack(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let _c = 3;
+            let _d = 4;
+            let _e = 5;
+            let _f = 6;
+            let _g = 7;
+            let h = io.0;
+            io.1 = h;
+        }
+
+        let mut inputs = IO(8, 0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = register_to_stack(8);
+        register_to_stack(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
-        let mut args = IO(0);
+        let mut args = IO(8, 0);
         ct.execute(&mut args);
-        assert_eq!(args.0, 8);
+        assert_eq!(args.1, inputs.1);
         assert_eq!(spills, 9); // f, g: i32, h:  u8.
-    }
-
-    fn stack_to_register() -> u8 {
-        let _a = 1;
-        let _b = 2;
-        let c = 3;
-        let _d = 4;
-        // When returning from `farg` all registers are full, so `e` needs to be allocated on the
-        // stack. However, after we have returned, anything allocated during `farg` is freed. Thus
-        // returning `e` will allocate a new local in a (newly freed) register, resulting in a `mov
-        // reg, [rbp]` instruction.
-        let e = farg(c);
-        e
     }
 
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
     fn test_mov_stack_to_register() {
         struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[interp_step]
+        fn stack_to_register(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let c = 3;
+            let _d = 4;
+            // When returning from `farg` all registers are full, so `e` needs to be allocated on the
+            // stack. However, after we have returned, anything allocated during `farg` is freed. Thus
+            // returning `e` will allocate a new local in a (newly freed) register, resulting in a `mov
+            // reg, [rbp]` instruction.
+            let e = farg(c);
+            io.0 = e;
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = stack_to_register();
+        stack_to_register(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
@@ -1654,52 +1730,32 @@ mod tests {
         assert_eq!(spills, 1); // Just one u8.
     }
 
-    fn ext_call() -> u64 {
-        extern "C" {
-            fn add_some(a: u64, b: u64, c: u64, d: u64, e: u64) -> u64;
-        }
-        let a = 1;
-        let b = 2;
-        let c = 3;
-        let d = 4;
-        let e = 5;
-        // When calling `add_some` argument `a` is loaded from a register, while the remaining
-        // arguments are loaded from the stack.
-        let expect = unsafe { add_some(a, b, c, d, e) };
-        expect
-    }
-
     #[test]
     fn ext_call_and_spilling() {
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[interp_step]
+        fn ext_call(io: &mut IO) {
+            let a = 1;
+            let b = 2;
+            let c = 3;
+            let d = 4;
+            let e = 5;
+            // When calling `add_some` argument `a` is loaded from a register, while the remaining
+            // arguments are loaded from the stack.
+            let expect = unsafe { add_some(a, b, c, d, e) };
+            io.0 = expect;
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = ext_call();
+        ext_call(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let mut args = IO(0);
         TraceCompiler::<IO>::compile(tir_trace).execute(&mut args);
         assert_eq!(inputs.0, 7);
         assert_eq!(inputs.0, args.0);
-    }
-
-    #[test]
-    fn test_trace_inputs() {
-        struct IO(u64, u64, u64);
-        let mut inputs = trace_inputs(IO(1, 2, 3));
-        let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = unsafe { add6(inputs.0, inputs.1, inputs.2, 4, 5, 6) };
-        let sir_trace = th.stop_tracing().unwrap();
-        let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
-        let ct = TraceCompiler::<IO>::compile(tir_trace);
-        let mut args = IO(1, 2, 3);
-        ct.execute(&mut args);
-        assert_eq!(inputs.0, 21);
-        assert_eq!(inputs.0, args.0);
-        // Execute once more with different arguments.
-        let mut args2 = IO(7, 8, 9);
-        ct.execute(&mut args2);
-        assert_eq!(args2.0, 39);
     }
 
     #[inline(never)]
@@ -1717,12 +1773,18 @@ mod tests {
     #[test]
     fn test_binop_add() {
         struct IO(u8, u64, u8, u8);
-        let mut inputs = trace_inputs(IO(0, 0, 0, 0));
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = add(13);
+            io.1 = add64(1);
+            io.2 = io.0 + 2;
+            io.3 = io.0 + io.0;
+        }
+
+        let mut inputs = IO(0, 0, 0, 0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = add(13);
-        inputs.1 = add64(1);
-        inputs.2 = inputs.0 + 2;
-        inputs.3 = inputs.0 + inputs.0;
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1739,16 +1801,22 @@ mod tests {
     #[test]
     fn test_binop_add_stack() {
         struct IO(u8, u64);
-        let mut inputs = trace_inputs(IO(0, 0));
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let _c = 3;
+            let _d = 4;
+            let _e = 5;
+            let _d = 6;
+            io.0 = add(13);
+            io.1 = add64(1);
+        }
+
+        let mut inputs = IO(0, 0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let _a = 1;
-        let _b = 2;
-        let _c = 3;
-        let _d = 4;
-        let _e = 5;
-        let _d = 6;
-        inputs.0 = add(13);
-        inputs.1 = add64(1);
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1759,7 +1827,9 @@ mod tests {
     }
 
     #[test]
-    fn field_projection() {
+    fn field_projection_tir() {
+        struct IO(u64);
+
         struct S {
             _x: u64,
             y: u64,
@@ -1769,11 +1839,15 @@ mod tests {
             s.y
         }
 
-        struct IO(());
-        let _ = trace_inputs(IO(()));
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let s = S { _x: 100, y: 200 };
+            io.0 = get_y(s);
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let s = S { _x: 100, y: 200 };
-        let _expect = get_y(s);
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
 
@@ -1807,21 +1881,22 @@ mod tests {
               ...", &tir_trace);
     }
 
-    fn ref_deref() -> u64 {
-        let mut x = 9;
-        let y = &mut x;
-        *y = 10;
-        let z = *y;
-        z
-    }
-
     #[test]
-    #[ignore] // FIXME: Need to type our projections.
     fn test_ref_deref() {
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let mut x = 9;
+            let y = &mut x;
+            *y = 10;
+            let z = *y;
+            io.0 = z
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = ref_deref();
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1831,18 +1906,27 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // FIXME: Need to type our projections.
     fn test_ref_deref_stack() {
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let _c = 3;
+            let _d = 4;
+            let _e = 5;
+            let _f = 6;
+            let mut x = 9;
+            let y = &mut x;
+            *y = 10;
+            let z = *y;
+            io.0 = z
+        }
+
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let _a = 1;
-        let _b = 2;
-        let _c = 3;
-        let _d = 4;
-        let _e = 5;
-        let _f = 6;
-        inputs.0 = ref_deref();
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1851,67 +1935,84 @@ mod tests {
         assert_eq!(args.0, 10);
     }
 
-    fn deref1(arg: u64) -> u64 {
-        let a = &arg;
-        return *a;
-    }
-
+    /// Dereferences a variable that lives on the stack and stores it in a register.
     #[test]
     fn test_deref_stack_to_register() {
-        // This test dereferences a variable that lives on the stack and stores it in a register.
+        fn deref1(arg: u64) -> u64 {
+            let a = &arg;
+            return *a;
+        }
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let _a = 1;
+            let _b = 2;
+            let _c = 3;
+            let f = 6;
+            io.0 = deref1(f);
+        }
+
         struct IO(u64);
         let mut inputs = trace_inputs(IO(0));
         let th = start_tracing(TracingKind::HardwareTracing);
-        let _a = 1;
-        let _b = 2;
-        let _c = 3;
-        let f = 6;
-        inputs.0 = deref1(f);
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
         let mut args = IO(0);
         ct.execute(&mut args);
         assert_eq!(args.0, 6);
-    }
-
-    fn deref2(arg: u64) -> u64 {
-        let a = &arg;
-        let _b = 2;
-        let _c = 3;
-        let _d = 4;
-        return *a;
     }
 
     #[test]
     fn test_deref_register_to_stack() {
-        // This test dereferences a variable that lives on the stack and stores it in a register.
         struct IO(u64);
-        let mut inputs = trace_inputs(IO(0));
+
+        fn deref2(arg: u64) -> u64 {
+            let a = &arg;
+            let _b = 2;
+            let _c = 3;
+            let _d = 4;
+            return *a;
+        }
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let f = 6;
+            io.0 = deref2(f);
+        }
+
+        // This test dereferences a variable that lives on the stack and stores it in a register.
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let f = 6;
-        inputs.0 = deref2(f);
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
         let mut args = IO(0);
         ct.execute(&mut args);
         assert_eq!(args.0, 6);
-    }
-
-    #[do_not_trace]
-    fn dont_trace_this(a: u8) -> u8 {
-        let b = 2;
-        let c = a + b;
-        c
     }
 
     #[test]
     fn test_do_not_trace() {
         struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+
+        #[do_not_trace]
+        fn dont_trace_this(a: u8) -> u8 {
+            let b = 2;
+            let c = a + b;
+            c
+        }
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 = dont_trace_this(io.0);
+        }
+
+        let mut inputs = IO(1);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.0 = dont_trace_this(1);
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
 
@@ -1927,24 +2028,24 @@ mod tests {
         );
 
         let ct = TraceCompiler::<IO>::compile(tir_trace);
-        let mut args = IO(0);
+        let mut args = IO(1);
         ct.execute(&mut args);
         assert_eq!(args.0, 3);
     }
 
-    fn dont_trace_stdlib(a: &mut Vec<u64>) -> u64 {
-        a.push(3);
-        3
-    }
-
     #[test]
     fn test_do_not_trace_stdlib() {
-        let mut vec: Vec<u64> = Vec::new();
         struct IO<'a>(&'a mut Vec<u64>);
-        let inputs = trace_inputs(IO(&mut vec));
+
+        #[interp_step]
+        fn dont_trace_stdlib(io: &mut IO) {
+            io.0.push(3);
+        }
+
+        let mut vec: Vec<u64> = Vec::new();
+        let mut inputs = IO(&mut vec);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let v = inputs.0;
-        dont_trace_stdlib(v);
+        dont_trace_stdlib(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1957,23 +2058,31 @@ mod tests {
 
     #[test]
     fn test_projection_chain() {
+        #[derive(Debug)]
+        struct IO((usize, u8, usize), u8, S, usize);
+
         #[derive(Debug, PartialEq)]
         struct S {
             x: usize,
             y: usize,
         }
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.1 = (io.0).1;
+            io.3 = io.2.y;
+        }
+
         let s = S { x: 5, y: 6 };
-        let t = (1usize, 2u8, 3usize);
-        struct IO((usize, u8, usize), u8, S, usize);
-        let mut inputs = trace_inputs(IO(t, 0u8, s, 0usize));
+        let t = (1, 2, 3);
+        let mut inputs = IO(t, 0u8, s, 0usize);
         let th = start_tracing(TracingKind::HardwareTracing);
-        inputs.1 = (inputs.0).1;
-        inputs.3 = inputs.2.y;
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
 
-        let t2 = (1usize, 2u8, 3usize);
+        let t2 = (1, 2, 3);
         let s2 = S { x: 5, y: 6 };
         let mut args = IO(t2, 0u8, s2, 0usize);
         ct.execute(&mut args);
@@ -1985,11 +2094,17 @@ mod tests {
 
     #[test]
     fn test_projection_lhs() {
-        let t = (1u8, 2u8);
         struct IO((u8, u8), u8);
-        let mut inputs = trace_inputs(IO(t, 3u8));
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            (io.0).1 = io.1;
+        }
+
+        let t = (1u8, 2u8);
+        let mut inputs = IO(t, 3u8);
         let th = start_tracing(TracingKind::HardwareTracing);
-        (inputs.0).1 = inputs.1;
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -1999,24 +2114,26 @@ mod tests {
         assert_eq!((args.0).1, 3);
     }
 
-    #[inline(never)]
-    fn array(a: &mut [u8; 3]) -> u8 {
-        let z = a[1];
-        z
-    }
-
     #[test]
     fn test_array() {
         struct IO<'a>(&'a mut [u8; 3], u8);
-        let mut a = [3u8, 4u8, 5u8];
-        let mut inputs = trace_inputs(IO(&mut a, 0));
+
+        #[interp_step]
+        #[inline(never)]
+        fn array(io: &mut IO) {
+            let z = io.0[1];
+            io.1 = z;
+        }
+
+        let mut a = [3, 4, 5];
+        let mut inputs = IO(&mut a, 0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let tmp = inputs.0;
-        inputs.1 = array(tmp);
+        array(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
+        assert_eq!(inputs.1, 4);
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
-        let mut a2 = [3u8, 4u8, 5u8];
+        let mut a2 = [3, 4, 5];
         let mut args = IO(&mut a2, 0);
         ct.execute(&mut args);
         assert_eq!(args.1, 4);
@@ -2025,15 +2142,16 @@ mod tests {
     /// Test codegen of field access on a struct ref on the right-hand side.
     #[test]
     fn rhs_struct_ref_field() {
-        fn add1(io: &mut IO) -> u8 {
-            io.0 + 1
+        struct IO(u8);
+
+        #[interp_step]
+        fn add1(io: &mut IO) {
+            io.0 = io.0 + 1
         }
 
-        struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let x = add1(&mut inputs);
-        inputs.0 = x;
+        add1(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -2046,16 +2164,16 @@ mod tests {
     /// Test codegen of indexing a struct ref on the left-hand side.
     #[test]
     fn mut_lhs_struct_ref() {
-        // FIXME return value not necessary, but we can't codegen returning nothing just yet.
-        fn set100(io: &mut IO) -> u8 {
+        struct IO(u8);
+
+        #[interp_step]
+        fn set100(io: &mut IO) {
             io.0 = 100;
-            0
         }
 
-        struct IO(u8);
-        let mut inputs = trace_inputs(IO(0));
+        let mut inputs = IO(0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let _ = set100(&mut inputs);
+        set100(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -2068,22 +2186,22 @@ mod tests {
     /// Test codegen of copying something which doesn't fit in a register.
     #[test]
     fn place_larger_than_reg() {
-        // FIXME return value not necessary, but we can't codegen returning nothing just yet.
-        fn ten(io: &mut IO) -> u8 {
-            io.0 = S(10, 10, 10);
-            0
-        }
-
         #[derive(Debug, Eq, PartialEq)]
         struct S(u64, u64, u64);
         struct IO(S);
 
-        let mut inputs = trace_inputs(IO(S(0, 0, 0)));
+        #[interp_step]
+        fn ten(io: &mut IO) {
+            io.0 = S(10, 10, 10);
+        }
+
+        let mut inputs = IO(S(0, 0, 0));
         let th = start_tracing(TracingKind::HardwareTracing);
-        let _ = ten(&mut inputs);
+        ten(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
+        assert_eq!(inputs.0, S(10, 10, 10));
 
         let mut args = IO(S(1, 1, 1));
         ct.execute(&mut args);
@@ -2091,6 +2209,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // FIXME Broken during new trimming scheme. Seg faults.
     fn test_rvalue_len() {
         struct IO<'a>(&'a [u8], u8);
 
@@ -2103,11 +2222,16 @@ mod tests {
             x
         }
 
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            let x = matchthis(&io, 0);
+            io.1 = x;
+        }
+
         let a = "abc".as_bytes();
-        let mut inputs = trace_inputs(IO(&a, 0));
+        let mut inputs = IO(&a, 0);
         let th = start_tracing(TracingKind::HardwareTracing);
-        let x = matchthis(&inputs, 0);
-        inputs.1 = x;
+        interp_step(&mut inputs);
         let sir_trace = th.stop_tracing().unwrap();
         let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
         let ct = TraceCompiler::<IO>::compile(tir_trace);
@@ -2115,5 +2239,31 @@ mod tests {
         let mut args = IO(&mut a2, 0);
         ct.execute(&mut args);
         assert_eq!(args.1, 1);
+    }
+
+    // Only `interp_step` annotated functions and their callees should remain after trace trimming.
+    #[test]
+    fn trim_junk() {
+        struct IO(u8);
+
+        #[interp_step]
+        fn interp_step(io: &mut IO) {
+            io.0 += 1;
+        }
+
+        let mut inputs = IO(0);
+        let th = start_tracing(TracingKind::HardwareTracing);
+        interp_step(&mut inputs);
+        inputs.0 = 0; // Should get trimmed.
+        interp_step(&mut inputs);
+        inputs.0 = 0; // Should get trimmed
+        interp_step(&mut inputs);
+        let sir_trace = th.stop_tracing().unwrap();
+        let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
+        let ct = TraceCompiler::<IO>::compile(tir_trace);
+
+        let mut args = IO(0);
+        ct.execute(&mut args);
+        assert_eq!(args.0, 3);
     }
 }

--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -70,7 +70,6 @@ mod tests {
             symbol_name: String::from("symbol1"),
             blocks: blocks1,
             flags: 0,
-            trace_inputs_local: None,
             local_decls: Vec::new(),
             num_args: 0,
         });
@@ -87,7 +86,6 @@ mod tests {
             symbol_name: String::from("symbol2"),
             blocks: blocks2,
             flags: 0,
-            trace_inputs_local: None,
             local_decls: Vec::new(),
             num_args: 0,
         });
@@ -190,7 +188,6 @@ mod tests {
                 symbol_name: String::from("symbol1"),
                 blocks: blocks_t1,
                 flags: 0,
-                trace_inputs_local: None,
                 local_decls: vec![lcl.clone(); 3],
                 num_args: 0,
             }),
@@ -201,7 +198,6 @@ mod tests {
                     Terminator::Unreachable,
                 )],
                 flags: 0,
-                trace_inputs_local: None,
                 local_decls: vec![lcl; 5],
                 num_args: 0,
             }),

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -390,6 +390,7 @@ pub mod bodyflags {
     pub const TRACE_HEAD: u8 = 1;
     pub const TRACE_TAIL: u8 = 1 << 1;
     pub const DO_NOT_TRACE: u8 = 1 << 2;
+    pub const INTERP_STEP: u8 = 1 << 3;
 }
 
 /// The definition of a local variable, including its type.

--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -387,10 +387,8 @@ impl Display for Projection {
 
 /// Bits in the `flags` bitfield in `Body`.
 pub mod bodyflags {
-    pub const TRACE_HEAD: u8 = 1;
-    pub const TRACE_TAIL: u8 = 1 << 1;
-    pub const DO_NOT_TRACE: u8 = 1 << 2;
-    pub const INTERP_STEP: u8 = 1 << 3;
+    pub const DO_NOT_TRACE: u8 = 1;
+    pub const INTERP_STEP: u8 = 1 << 1;
 }
 
 /// The definition of a local variable, including its type.
@@ -412,7 +410,6 @@ pub struct Body {
     pub symbol_name: String,
     pub blocks: Vec<BasicBlock>,
     pub flags: u8,
-    pub trace_inputs_local: Option<Local>,
     pub local_decls: Vec<LocalDecl>,
     pub num_args: usize,
 }
@@ -1047,8 +1044,6 @@ pub struct Types {
     pub cgu_hash: CguHash,
     /// The types themselves. Combine `cgu_hash` with an index into this to make a type ID.
     pub types: Vec<Ty>,
-    /// Indices of `types` which are thread tracers.
-    pub thread_tracers: Vec<u32>,
 }
 
 #[cfg(test)]

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -1,9 +1,8 @@
 //! Hardware tracing via ykrustc.
 
 use super::{SirTrace, ThreadTracer, ThreadTracerImpl};
-use crate::{errors::InvalidTraceError, sir::SIR, SirLoc};
+use crate::{errors::InvalidTraceError, SirLoc};
 use hwtracer::backends::TracerBuilder;
-use ykpack::Local;
 
 pub mod mapper;
 use mapper::HWTMapper;
@@ -22,12 +21,6 @@ impl SirTrace for HWTSirTrace {
     fn raw_loc(&self, idx: usize) -> &SirLoc {
         &self.sirtrace[idx]
     }
-
-    fn input(&self) -> Local {
-        let blk = (self as &dyn SirTrace).into_iter().next().unwrap();
-        let body = &SIR.bodies[&blk.symbol_name];
-        body.trace_inputs_local.unwrap()
-    }
 }
 
 /// Hardware thread tracer.
@@ -36,7 +29,6 @@ struct HWTThreadTracer {
 }
 
 impl ThreadTracerImpl for HWTThreadTracer {
-    #[trace_tail]
     fn stop_tracing(&mut self) -> Result<Box<dyn SirTrace>, InvalidTraceError> {
         let hwtrace = self.ttracer.stop_tracing().unwrap();
         let mt = HWTMapper::new();
@@ -46,7 +38,6 @@ impl ThreadTracerImpl for HWTThreadTracer {
     }
 }
 
-#[trace_head]
 pub fn start_tracing() -> ThreadTracer {
     let tracer = TracerBuilder::new().build().unwrap();
     let mut ttracer = (*tracer).thread_tracer();
@@ -87,10 +78,5 @@ mod tests {
     #[test]
     fn test_in_bounds_trace_indices() {
         test_helpers::test_in_bounds_trace_indices(TRACING_KIND);
-    }
-
-    #[test]
-    fn test_trace_iterator() {
-        test_helpers::test_trace_iterator(TRACING_KIND);
     }
 }

--- a/yktrace/src/sir.rs
+++ b/yktrace/src/sir.rs
@@ -4,7 +4,7 @@ use fallible_iterator::FallibleIterator;
 use memmap::Mmap;
 use object::{Object, ObjectSection};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     convert::TryFrom,
     env,
     fmt::{self, Debug, Display, Write},
@@ -13,7 +13,7 @@ use std::{
     iter::Iterator,
     path::Path
 };
-use ykpack::{self, bodyflags, Body, CguHash, Decoder, Local, Pack, Ty};
+use ykpack::{self, bodyflags, Body, CguHash, Decoder, Pack, Ty};
 
 /// The serialised IR loaded in from disk. One of these structures is generated in the above
 /// `lazy_static` and is shared immutably for all threads.
@@ -21,43 +21,14 @@ use ykpack::{self, bodyflags, Body, CguHash, Decoder, Local, Pack, Ty};
 pub struct Sir {
     /// Lets us map a symbol name to a SIR body.
     pub bodies: HashMap<String, Body>,
-    // Interesting locations that we need quick access to.
-    pub markers: SirMarkers,
     /// SIR Local variable types, keyed by codegen unit hash.
-    pub types: HashMap<CguHash, Vec<Ty>>,
-    /// Thread tracer type IDs.
-    pub thread_tracers: HashSet<ykpack::TypeId>
+    pub types: HashMap<CguHash, Vec<Ty>>
 }
 
 impl Sir {
     pub fn ty(&self, id: &ykpack::TypeId) -> &ykpack::Ty {
         &self.types[&id.0][usize::try_from(id.1).unwrap()]
     }
-
-    pub fn is_thread_tracer_ty(&self, id: &ykpack::TypeId) -> bool {
-        self.thread_tracers.contains(id)
-    }
-}
-
-/// Records interesting locations required for trace manipulation.
-#[derive(Debug)]
-pub struct SirMarkers {
-    /// Functions which start tracing and whose suffix gets trimmed off the top of traces.
-    /// Although you'd expect only one such function, (i.e. `yktrace::start_tracing`), in fact
-    /// the location which appears in the trace can vary according to how Rust compiles the
-    /// program (this happens even if `yktracer::start_tracing()` is marked `#[inline(never)]`).
-    /// For this reason, we mark few different places as potential heads.
-    ///
-    /// We will only see the suffix of these functions in traces, as trace recording will start
-    /// somewhere in the middle of them.
-    ///
-    /// The compiler is made aware of this location by the `#[trace_head]` annotation.
-    pub trace_heads: Vec<String>,
-    /// Similar to `trace_heads`, functions which stop tracing and whose prefix gets trimmed off
-    /// the bottom of traces.
-    ///
-    /// The compiler is made aware of these locations by the `#[trace_tail]` annotation.
-    pub trace_tails: Vec<String>
 }
 
 lazy_static! {
@@ -74,9 +45,6 @@ impl Sir {
         // memory.
         let mut bodies = HashMap::new();
         let mut types = HashMap::new();
-        let mut trace_heads = Vec::new();
-        let mut trace_tails = Vec::new();
-        let mut thread_tracers = HashSet::new();
         for sec in object.sections() {
             if sec.name().unwrap().starts_with(".yksir_") {
                 let mut curs = Cursor::new(sec.data().unwrap());
@@ -85,15 +53,6 @@ impl Sir {
                 while let Some(pack) = dec.next().unwrap() {
                     match pack {
                         Pack::Body(body) => {
-                            // Cache some locations that we need quick access to.
-                            if body.flags & bodyflags::TRACE_HEAD != 0 {
-                                trace_heads.push(body.symbol_name.clone());
-                            }
-
-                            if body.flags & bodyflags::TRACE_TAIL != 0 {
-                                trace_tails.push(body.symbol_name.clone());
-                            }
-
                             // Due to the way Rust compiles stuff, duplicates may exist. Where
                             // duplicates exist, the functions will be identical, but may have
                             // different (but equivalent) types. This is because types too may be
@@ -105,28 +64,13 @@ impl Sir {
                         Pack::Types(ts) => {
                             let old = types.insert(ts.cgu_hash, ts.types);
                             debug_assert!(old.is_none()); // There's one `Types` pack per codegen unit.
-                            for idx in ts.thread_tracers {
-                                thread_tracers.insert((ts.cgu_hash, idx));
-                            }
                         }
                     }
                 }
             }
         }
 
-        assert!(!trace_heads.is_empty(), "no trace heads found!");
-        assert!(!trace_tails.is_empty(), "no trace tails found!");
-        let markers = SirMarkers {
-            trace_heads,
-            trace_tails
-        };
-
-        Ok(Sir {
-            bodies,
-            markers,
-            types,
-            thread_tracers
-        })
+        Ok(Sir { bodies, types })
     }
 }
 
@@ -136,23 +80,11 @@ impl Display for Sir {
             writeln!(f, "{}", body)?;
         }
 
-        for head in &self.markers.trace_heads {
-            writeln!(f, "HEAD {}", head)?;
-        }
-
-        for tail in &self.markers.trace_tails {
-            writeln!(f, "TAIL {}", tail)?;
-        }
-
         for (cgu_hash, types) in self.types.iter() {
             writeln!(f, "TYPES OF {}", cgu_hash)?;
             for ty in types {
                 writeln!(f, "{}", ty)?;
             }
-        }
-
-        for thread_tracer in self.thread_tracers.iter() {
-            writeln!(f, "THREAD TRACER {}:{}", thread_tracer.0, thread_tracer.1)?;
         }
 
         Ok(())
@@ -186,9 +118,6 @@ pub trait SirTrace: Debug {
 
     /// Returns the SIR location at index `idx` in the *raw* (untrimmed) trace.
     fn raw_loc(&self, idx: usize) -> &SirLoc;
-
-    /// Returns the local variable containing the trace inputs tuple.
-    fn input(&self) -> Local;
 }
 
 impl<'a> IntoIterator for &'a dyn SirTrace {
@@ -196,7 +125,7 @@ impl<'a> IntoIterator for &'a dyn SirTrace {
     type IntoIter = SirTraceIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        SirTraceIterator::new(&*SIR, self)
+        SirTraceIterator::new(self)
     }
 }
 
@@ -210,17 +139,13 @@ pub fn sir_trace_str(sir: &Sir, trace: &dyn SirTrace, trimmed: bool, show_blocks
     let mut res = String::new();
     let res_r = &mut res;
 
-    write!(res_r, "Trace input local: {}\n\n", trace.input()).unwrap();
     for loc in locs {
         write!(res_r, "[{}] bb={}, flags=[", loc.symbol_name, loc.bb_idx).unwrap();
 
         let body = sir.bodies.get(&loc.symbol_name);
         if let Some(body) = body {
-            if body.flags & bodyflags::TRACE_HEAD != 0 {
-                write!(res_r, "HEAD ").unwrap();
-            }
-            if body.flags & bodyflags::TRACE_TAIL != 0 {
-                write!(res_r, "TAIL ").unwrap();
+            if body.flags & bodyflags::INTERP_STEP != 0 {
+                write!(res_r, "INTERP_STEP ").unwrap();
             }
         }
         writeln!(res_r, "]").unwrap();
@@ -249,29 +174,13 @@ impl Display for dyn SirTrace {
 
 /// An iterator over a trimmed SIR trace.
 pub struct SirTraceIterator<'a> {
-    sir: &'a Sir,
     trace: &'a dyn SirTrace,
     next_idx: usize
 }
 
 impl<'a> SirTraceIterator<'a> {
-    pub fn new(sir: &'a Sir, trace: &'a dyn SirTrace) -> Self {
-        // We are going to present a "trimmed trace", so we do a backwards scan looking for the end
-        // of the code that starts the tracer.
-        let mut begin_idx = None;
-        for blk_idx in (0..trace.raw_len()).rev() {
-            let sym = &trace.raw_loc(blk_idx).symbol_name;
-            if sir.markers.trace_heads.contains(sym) {
-                begin_idx = Some(blk_idx + 1);
-                break;
-            }
-        }
-
-        SirTraceIterator {
-            sir,
-            trace,
-            next_idx: begin_idx.expect("Couldn't find the end of the code that starts the tracer")
-        }
+    pub fn new(trace: &'a dyn SirTrace) -> Self {
+        SirTraceIterator { trace, next_idx: 0 }
     }
 }
 
@@ -280,18 +189,9 @@ impl<'a> Iterator for SirTraceIterator<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next_idx < self.trace.raw_len() {
-            let sym = &self.trace.raw_loc(self.next_idx).symbol_name;
-            if self.sir.markers.trace_tails.contains(sym) {
-                // Stop when we find the start of the code that stops the tracer, thus trimming the
-                // end of the trace. By setting the next index to one above the last one in the
-                // trace, we ensure the iterator will return `None` forever more.
-                self.next_idx = self.trace.raw_len();
-                None
-            } else {
-                let ret = self.trace.raw_loc(self.next_idx);
-                self.next_idx += 1;
-                Some(ret)
-            }
+            let ret = self.trace.raw_loc(self.next_idx);
+            self.next_idx += 1;
+            Some(ret)
         } else {
             None // No more locations.
         }

--- a/yktrace/src/swt.rs
+++ b/yktrace/src/swt.rs
@@ -46,19 +46,12 @@ impl SirTrace for SWTSirTrace {
     fn raw_loc(&self, idx: usize) -> &SirLoc {
         &self.locs[idx]
     }
-
-    fn input(&self) -> Local {
-        let blk = (self as &dyn SirTrace).into_iter().next().unwrap();
-        let body = &SIR.bodies[&blk.symbol_name];
-        body.trace_inputs_local.unwrap()
-    }
 }
 
 /// Softare thread tracer.
 struct SWTThreadTracer;
 
 impl ThreadTracerImpl for SWTThreadTracer {
-    #[trace_tail]
     fn stop_tracing(&mut self) -> Result<Box<dyn SirTrace>, InvalidTraceError> {
         let mut len = 0;
         let buf = unsafe { yk_swt_stop_tracing_impl(&mut len) };
@@ -70,7 +63,6 @@ impl ThreadTracerImpl for SWTThreadTracer {
     }
 }
 
-#[trace_head]
 pub fn start_tracing() -> ThreadTracer {
     unsafe {
         yk_swt_start_tracing_impl();
@@ -283,10 +275,5 @@ mod tests {
     #[test]
     fn test_in_bounds_trace_indices() {
         test_helpers::test_in_bounds_trace_indices(TRACING_KIND);
-    }
-
-    #[test]
-    fn test_trace_iterator() {
-        test_helpers::test_trace_iterator(TRACING_KIND);
     }
 }

--- a/ykview/src/main.rs
+++ b/ykview/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
                 addr: None,
             });
         }
-        for loc in yktrace::sir::SirTraceIterator::new(&sir, &trace) {
+        for loc in yktrace::sir::SirTraceIterator::new(&trace) {
             println!("{:?}", loc);
         }
         let tir = yktrace::tir::TirTrace::new(&sir, &trace).unwrap();
@@ -59,9 +59,5 @@ impl yktrace::sir::SirTrace for VecSirTrace {
 
     fn raw_loc(&self, idx: usize) -> &yktrace::sir::SirLoc {
         &self.0[idx]
-    }
-
-    fn input(&self) -> ykpack::Local {
-        self.1
     }
 }


### PR DESCRIPTION
Here's the new trimming scheme for yk.

The first commit contains changes to the codegen to fix problems that were exposed by the trimming changes. One previously passing test remains marked `#[ignore] // FIXME`, but as agreed offline, since we are thinking of changing the IR quite fundamentally, we won't get hung up on it.

The second commit removes all the stuff that we no longer need.

Companion PR ~~coming~~ https://github.com/softdevteam/ykrustc/pull/136.