### PR TITLE
Add a simple trace debugging facility.

### DIFF
--- a/ykcompile/Cargo.toml
+++ b/ykcompile/Cargo.toml
@@ -13,9 +13,11 @@ ykpack = { path = "../ykpack" }
 dynasmrt = "1.0.0"
 hex = "0.4.2"
 libc = "0.2.80"
-fm = "0.1.4"
-regex = "1.4.2"
 lazy_static = "1.4.0"
 
 [build-dependencies]
 cc = "1.0.62"
+
+[dev-dependencies]
+fm = "0.1.4"
+regex = "1.4.2"

--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -933,7 +933,7 @@ impl<TT> TraceCompiler<TT> {
             Statement::StorageDead(l) => self.free_register(l)?,
             Statement::Call(target, args, dest) => self.c_call(target, args, dest)?,
             Statement::Cast(dest, src) => self.c_cast(dest, src),
-            Statement::Nop => {}
+            Statement::Nop | Statement::Debug(..) => {}
             Statement::Unimplemented(s) => todo!("{:?}", s),
         }
 
@@ -1736,7 +1736,8 @@ mod tests {
     }
 
     /// Fuzzy matches the textual TIR for the trace `tt` with the pattern `ptn`.
-    fn assert_tir(ptn: &str, tt: &TirTrace) {
+    /// Duplicated from yktrace, since you can't share things inside #[cfg(test)] between crates.
+    pub fn assert_tir(ptn: &str, tt: &TirTrace) {
         let ptn_re = Regex::new(r"%.+?\b").unwrap(); // Names are words prefixed with `%`.
         let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
         let matcher = FMBuilder::new(ptn)
@@ -1748,8 +1749,7 @@ mod tests {
 
         let res = matcher.matches(&format!("{}", tt));
         if let Err(e) = res {
-            eprintln!("{}", e); // Visible when tests run with --nocapture.
-            panic!(e);
+            panic!("{}", e);
         }
     }
 

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -16,3 +16,7 @@ gimli = "0.23.0"
 object = "0.22.0"
 memmap = "0.7.0"
 fxhash = "0.2.1"
+
+[dev-dependencies]
+fm = "0.1.4"
+regex = "1.4.2"

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -85,6 +85,14 @@ pub fn start_tracing(kind: TracingKind) -> ThreadTracer {
     }
 }
 
+/// A debugging aid for traces.
+/// Calls to this function are recognised by Yorick and a special debug TIR statement is inserted
+/// into the trace. Interpreter writers should compile-time guard calls to this so as to only emit
+/// the extra bytecodes when explicitely turned on.
+#[inline(never)]
+#[trace_debug]
+pub fn trace_debug(_msg: &'static str) {}
+
 /// The bodies of tests that we want to run on all tracing kinds live in here.
 #[cfg(test)]
 mod test_helpers {


### PR DESCRIPTION
Companion PR ~~coming~~: https://github.com/softdevteam/ykrustc/pull/144.

We add a special function, yktrace::trace_debug(msg: &'static str).

When the interpreter author calls this special function, the SIR generator
recognises this and, instead of emitting a regular Call terminator, inserts a
special TraceDebugCall terminator. This terminator contains only the bare
minimum for the TIR compiler to later translate the terminator into a Debug
statement, which when printed, looks like a comment in the trace.

For example if the interpreter author sprinkled calls like this in their code:
```
...
trace_debug("Add 10");
...
trace_debug("Multiply 2");
...
```

Then the corresponding stringified trace might look like:
```
  ...
  // Add 10
  $6 = *($1+0)+8 + 10usize (checked)
  $7 = $6
  dead($6)
  guard($7+8, bool(false))
  *($1+0)+8 = $7
  dead($7)
  $0 = ()
  guard(*$1+0, integer(2))
  // Multiply 2
  $2 = *($1+0)+8 * 2usize (checked)
  ...
```

The idea is that interpreter authors could put these debugging statements at key
points in their implementation (e.g. at the start of each bytecode) to aid
debugging. They would want to compile-time guard the calls though, so that the
instrumentation is opt-in.