### PR TITLE
Add SIR interpreter.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members=[
     "yktrace",
     "ykcompile",
     "ykview",
+    "ykbh",
 ]
 
 [profile.dev]

--- a/ykbh/Cargo.toml
+++ b/ykbh/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["Lukas Diekmann <lukas.diekmann@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 yktrace = { path = "../yktrace" }
 ykpack = { path = "../ykpack" }
-ykcompile = { path = "../ykcompile" }

--- a/ykbh/Cargo.toml
+++ b/ykbh/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ykbh"
+version = "0.1.0"
+authors = ["Lukas Diekmann <lukas.diekmann@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+yktrace = { path = "../yktrace" }
+ykpack = { path = "../ykpack" }
+ykcompile = { path = "../ykcompile" }

--- a/ykbh/src/lib.rs
+++ b/ykbh/src/lib.rs
@@ -221,10 +221,7 @@ mod tests {
     use yktrace::sir::SIR;
 
     fn interp(fname: &str, tio: usize) {
-        let body = match SIR.bodies.get(fname) {
-            Some(b) => b,
-            None => panic!("No SIR")
-        };
+        let body = SIR.bodies.get(fname).expect("No SIR");
         let mut vars: Vec<Option<Object>> = vec![None; body.local_decls.len()];
         vars[1] = Some(Object::from_usize(tio));
         let mut si = SIRInterpreter::new(vars);

--- a/ykbh/src/lib.rs
+++ b/ykbh/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(test)]
-extern crate test;
-
 use ykpack::{self, Local, Terminator, Statement, IPlace, Constant, ConstantInt, UnsignedInt};
 use yktrace::sir::SIR;
 use std::convert::TryInto;
@@ -17,7 +14,7 @@ impl Object {
 
     /// Creates a new Object from a `usize`.
     fn from_usize(ptr: usize) -> Object {
-        let data = ptr.to_be_bytes();
+        let data = ptr.to_ne_bytes();
         Object {
             data: Vec::from(data)
         }
@@ -32,7 +29,7 @@ impl Object {
 
     /// Converts the objects data back to a `usize`.
     fn to_usize(&self) -> usize {
-        usize::from_be_bytes(self.data.as_slice().try_into().expect("Unexpected data length."))
+        usize::from_ne_bytes(self.data.as_slice().try_into().expect("Unexpected data length."))
     }
 
     /// Given a pointer and size, creates a new object by copying `size` data from `ptr`.
@@ -153,7 +150,6 @@ impl SIRInterpreter {
                 }
             }
             IPlace::Indirect { ptr, off, ty } => {
-                // FIXME copy only depending on type?
                 // Dereference a pointer and copy the data it points to.
                 if let Some(obj) = self.get_var(&ptr.local) {
                     let dstptr = obj.to_usize() + ptr.off as usize + *off as usize;

--- a/ykbh/src/lib.rs
+++ b/ykbh/src/lib.rs
@@ -91,7 +91,7 @@ impl SIRInterpreter {
 
     /// Get the Object referenced by a Local.
     fn get_var(&self, local: &Local) -> &Option<Object> {
-        &self.vars[usize::try_from(local.0).expect("Can't convert local to usize.")]
+        &self.vars[usize::try_from(local.0).unwrap()]
     }
 
     /// Implements the Store statement.
@@ -106,7 +106,7 @@ impl SIRInterpreter {
             IPlace::Val { local, off, ty: _ty } => {
                 // Store into a local.
                 if *off == 0 {
-                    self.vars[usize::try_from(local.0).expect("Can't convert local to usize.")] = Some(src);
+                    self.vars[usize::try_from(local.0).unwrap()] = Some(src);
                 } else {
                     todo!()
                 }
@@ -114,7 +114,7 @@ impl SIRInterpreter {
             IPlace::Indirect { ptr, off, ty: _ty } => {
                 // Write to a pointer.
                 if let Some(obj) = self.get_var(&ptr.local) {
-                    let dstptr = obj.to_usize() + usize::try_from(ptr.off).expect("Can't convert offset to usize.") + usize::try_from(*off).expect("Can't convert offset to usize.");
+                    let dstptr = obj.to_usize() + usize::try_from(ptr.off).unwrap() + usize::try_from(*off).unwrap();
                     self.store_raw(dstptr, src);
                 }
             }
@@ -141,9 +141,9 @@ impl SIRInterpreter {
                 } else {
                     // Copy data from an offset, e.g. $1 = $2+2.
                     if let Some(obj) = self.get_var(local) {
-                        let ptr = obj.data.as_ptr() as usize + usize::try_from(*off).expect("Can't convert offset to usize.");
+                        let ptr = obj.data.as_ptr() as usize + usize::try_from(*off).unwrap();
                         let size = SIR.ty(ty).size();
-                        Object::from_ptr(ptr, usize::try_from(size).expect("Can't convert size to usize."))
+                        Object::from_ptr(ptr, usize::try_from(size).unwrap())
                     } else {
                         unreachable!()
                     }
@@ -152,9 +152,9 @@ impl SIRInterpreter {
             IPlace::Indirect { ptr, off, ty } => {
                 // Dereference a pointer and copy the data it points to.
                 if let Some(obj) = self.get_var(&ptr.local) {
-                    let dstptr = obj.to_usize() + usize::try_from(ptr.off).expect("Can't offset to usize.") + usize::try_from(*off).expect("Can't convert offset to usize.");
+                    let dstptr = obj.to_usize() + usize::try_from(ptr.off).unwrap() + usize::try_from(*off).unwrap();
                     let size = SIR.ty(ty).size();
-                    Object::from_ptr(dstptr, usize::try_from(size).expect("Can't convert size to usize."))
+                    Object::from_ptr(dstptr, usize::try_from(size).unwrap())
                 } else {
                     unreachable!()
                 }
@@ -195,7 +195,7 @@ impl SIRInterpreter {
                     // The pointer to the vector should remain valid, since no changes to the
                     // vector later on will change its size, and so it won't be reallocated.
                     // FIXME: Check this is true!
-                    let ptr = obj.data.as_ptr() as usize + usize::try_from(*off).expect("Can't convert offset to usize.");
+                    let ptr = obj.data.as_ptr() as usize + usize::try_from(*off).unwrap();
                     Object::from_usize(ptr)
                 } else {
                     unreachable!()
@@ -203,7 +203,7 @@ impl SIRInterpreter {
             }
             IPlace::Indirect { ptr, off, ty: _ty } => {
                 if let Some(obj) = self.get_var(&ptr.local) {
-                    let ptr = obj.to_usize() + usize::try_from(ptr.off).expect("Can't convert offset to usize.") + usize::try_from(*off).expect("Can't convert offset to usize.");
+                    let ptr = obj.to_usize() + usize::try_from(ptr.off).unwrap() + usize::try_from(*off).unwrap();
                     Object::from_usize(ptr)
                 } else {
                     unreachable!()

--- a/ykbh/src/lib.rs
+++ b/ykbh/src/lib.rs
@@ -1,0 +1,310 @@
+#![feature(test)]
+extern crate test;
+
+use ykpack::{self, Local, Terminator, Statement, IPlace, Constant, ConstantInt, UnsignedInt};
+use yktrace::sir::SIR;
+use std::convert::TryInto;
+
+const ZST: Object = Object { data: Vec::new() };
+
+#[derive(Clone, Debug)]
+/// A data object, storing bytes.
+pub struct Object {
+    data: Vec<u8>
+}
+
+impl Object {
+
+    /// Creates a new Object from a `usize`.
+    fn from_usize(ptr: usize) -> Object {
+        let data = ptr.to_be_bytes();
+        Object {
+            data: Vec::from(data)
+        }
+    }
+
+    /// Creates a new Object from a `u8`.
+    fn from_u8(val: u8) -> Object {
+        Object {
+            data: Vec::from([val])
+        }
+    }
+
+    /// Converts the objects data back to a `usize`.
+    fn to_usize(&self) -> usize {
+        usize::from_be_bytes(self.data.as_slice().try_into().expect("Unexpected data length."))
+    }
+
+    /// Given a pointer and size, creates a new object by copying `size` data from `ptr`.
+    fn from_ptr(ptr: usize, size: usize) -> Object {
+        let mut data = Vec::with_capacity(size);
+        unsafe {
+            std::ptr::copy(ptr as *const u8, data.as_mut_ptr(), size);
+            data.set_len(size);
+        }
+        Object {
+            data
+        }
+    }
+}
+
+pub struct SIRInterpreter {
+    vars: Vec<Option<Object>>,
+}
+
+impl SIRInterpreter {
+    pub fn new(vars: Vec<Option<Object>>) -> Self {
+        SIRInterpreter {
+            vars,
+        }
+    }
+
+    pub fn interpret(&mut self, body: &ykpack::Body) {
+        // Ignore yktrace::trace_debug.
+        if body.flags & ykpack::bodyflags::TRACE_DEBUG != 0 {
+            return;
+        }
+
+        for stmt in body.blocks[0].stmts.iter() {
+            match stmt {
+                Statement::MkRef(dest, src) => self.mkref(dest, src),
+                Statement::DynOffs { .. } => todo!("dynoffs"),
+                Statement::Store(dest, src) => self.store(dest, src),
+                Statement::BinaryOp { .. } => todo!("binop"),
+                Statement::Nop => {},
+                Statement::Unimplemented(_) | Statement::Debug(_) => { todo!("Unimplemented") },
+                Statement::Cast(..) => todo!("cast"),
+                Statement::Call(..) | Statement::StorageDead(_) => unreachable!()
+            }
+        }
+
+        match &body.blocks[0].term {
+            Terminator::Call {
+                operand: _op,
+                args: _args,
+                destination: _dest
+            } => {
+                todo!()
+            }
+            Terminator::Return => {
+            }
+            t => todo!("{}", t)
+        }
+    }
+
+    /// Get the Object referenced by a Local.
+    fn get_var(&self, local: &Local) -> &Option<Object> {
+        &self.vars[local.0 as usize]
+    }
+
+    /// Implements the Store statement.
+    fn store(&mut self, dest: &IPlace, src: &IPlace) {
+        self.store_obj(dest, self.to_obj(src));
+    }
+
+    /// Write an Object to an IPlace. This either creates a new Object if the IPlace is a Val, or
+    /// writes the data to some pointer, if the IPlace is an Indirect.
+    fn store_obj(&mut self, dest: &IPlace, src: Object) {
+        match dest {
+            IPlace::Val { local, off, ty: _ty } => {
+                // Store into a local.
+                if *off == 0 {
+                    self.vars[local.0 as usize] = Some(src);
+                } else {
+                    todo!()
+                }
+            }
+            IPlace::Indirect { ptr, off, ty: _ty } => {
+                // Write to a pointer.
+                if let Some(obj) = self.get_var(&ptr.local) {
+                    let dstptr = obj.to_usize() + ptr.off as usize + *off as usize;
+                    self.store_raw(dstptr, src);
+                }
+            }
+            _ => unreachable!()
+        };
+    }
+
+    fn store_raw(&self, dest: usize, src: Object) {
+        unsafe {
+            std::ptr::copy(src.data.as_ptr(), dest as *mut u8, src.data.len());
+        }
+    }
+
+    fn to_obj(&self, src: &IPlace) -> Object {
+        match src {
+            IPlace::Val { local, off, ty } => {
+                if *off == 0 {
+                    // If the offset is 0 we can just copy the object, e.g. $1 = $2.
+                    if let Some(obj) = self.get_var(local) {
+                        obj.clone()
+                    } else {
+                        unreachable!()
+                    }
+                } else {
+                    // Copy data from an offset, e.g. $1 = $2+2.
+                    if let Some(obj) = self.get_var(local) {
+                        let ptr = obj.data.as_ptr() as usize + *off as usize;
+                        let size = SIR.ty(ty).size();
+                        Object::from_ptr(ptr, size as usize)
+                    } else {
+                        unreachable!()
+                    }
+                }
+            }
+            IPlace::Indirect { ptr, off, ty } => {
+                // FIXME copy only depending on type?
+                // Dereference a pointer and copy the data it points to.
+                if let Some(obj) = self.get_var(&ptr.local) {
+                    let dstptr = obj.to_usize() + ptr.off as usize + *off as usize;
+                    let size = SIR.ty(ty).size();
+                    Object::from_ptr(dstptr, size as usize)
+                } else {
+                    unreachable!()
+                }
+            }
+            IPlace::Const { val, ty: _ty } => {
+                // The source is a constant: create a new object.
+                match val {
+                    Constant::Int(ci) => match ci {
+                        ConstantInt::UnsignedInt(ui) => {
+                            match ui {
+                                UnsignedInt::U8(v) => Object::from_u8(*v),
+                                _ => todo!()
+                            }
+                        }
+                        ConstantInt::SignedInt(_si) => todo!(),
+                    },
+                    Constant::Bool(_b) => todo!(),
+                    Constant::Tuple(t) => {
+                        if SIR.ty(t).size() == 0 {
+                            ZST
+                        } else {
+                            todo!()
+                        }
+                    },
+                    _ => todo!(),
+                }
+            }
+            _ => todo!()
+        }
+    }
+
+
+    /// Creates a reference to an IPlace.
+    fn mkref(&mut self, dest: &IPlace, src: &IPlace) {
+        let obj = match src {
+            IPlace::Val { local, off, ty: _ty } => {
+                if let Some(obj) = self.get_var(local) {
+                    // The pointer to the vector should remain valid, since no changes to the
+                    // vector later on will change its size, and so it won't be reallocated.
+                    // FIXME: Check this is true!
+                    let ptr = obj.data.as_ptr() as usize + *off as usize;
+                    Object::from_usize(ptr)
+                } else {
+                    unreachable!()
+                }
+            }
+            IPlace::Indirect { ptr, off, ty: _ty } => {
+                if let Some(obj) = self.get_var(&ptr.local) {
+                    let ptr = obj.to_usize() + ptr.off as usize + *off as usize;
+                    Object::from_usize(ptr)
+                } else {
+                    unreachable!()
+                }
+            }
+            _ => todo!()
+        };
+        self.store_obj(dest, obj);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SIRInterpreter, Object};
+    use yktrace::sir::SIR;
+
+    fn interp(fname: &str, tio: usize) {
+        let body = match SIR.bodies.get(fname) {
+            Some(b) => b,
+            None => panic!("No SIR")
+        };
+        let mut vars: Vec<Option<Object>> = vec![None; body.local_decls.len()];
+        vars[1] = Some(Object::from_usize(tio));
+        let mut si = SIRInterpreter::new(vars);
+        si.interpret(body);
+    }
+
+    #[test]
+    fn test_simple() {
+        struct IO(u8, u8);
+        #[no_mangle]
+        fn simple(io: &mut IO) {
+            let a = 3;
+            io.1 = a;
+        }
+        let tio = IO(0, 0);
+        interp("simple", &tio as *const _ as usize);
+        assert_eq!(tio.1, 3);
+    }
+
+    #[test]
+    fn test_tuple() {
+        struct IO((u8, u8, u8));
+        #[no_mangle]
+        fn func_tuple(io: &mut IO) {
+            let a = io.0;
+            let b = a.2;
+            io.0.1 = b;
+        }
+
+        let tio = IO((1,2,3));
+        interp("func_tuple", &tio as *const _ as usize);
+        assert_eq!(tio.0, (1,3,3));
+    }
+
+    #[test]
+    fn test_ref() {
+        struct IO(u8, u8);
+        #[no_mangle]
+        fn func_ref(io: &mut IO) {
+            let a = 5u8;
+            let b = &a;
+            io.1 = *b;
+        }
+
+        let tio = IO(5, 0);
+        interp("func_ref", &tio as *const _ as usize);
+        assert_eq!(tio.1, 5);
+    }
+
+    #[test]
+    fn test_tupleref() {
+        struct IO((u8, u8));
+        #[no_mangle]
+        fn func_tupleref(io: &mut IO) {
+            let a = io.0;
+            io.0.1 = 5; // Make sure the line above copies.
+            let b = &a;
+            io.0.0 = b.1;
+        }
+
+        let tio = IO((0, 3));
+        interp("func_tupleref", &tio as *const _ as usize);
+        assert_eq!(tio.0, (3, 5));
+    }
+
+    #[test]
+    fn test_doubleref() {
+        struct IO((u8, u8));
+        #[no_mangle]
+        fn func_doubleref(io: &mut IO) {
+            let a = &io.0;
+            io.0.0 = a.1;
+        }
+
+        let tio = IO((0, 3));
+        interp("func_doubleref", &tio as *const _ as usize);
+        assert_eq!(tio.0, (3, 3));
+    }
+}


### PR DESCRIPTION
This PR adds an early version of our SIR interpreter. There's obviously much we can improve here, and this also doesn't handle nested frames yet. I tried to keep the first version (and PR) of this as small as possible, to get any early design flaws out of the way first before we move on.

One obvious improvement would be the use of vectors for the storage of data. We currently have two alternative ideas:

1) Use arrays instead of vecs which requires some lifetime shenanigans.
2) Allocate one big chunk of memory (i.e. [u8]) for each frame, whose size is equal to the size of all locals in the frame (which we can pre-compute), and then an `Object` is simply a slice into that chunk.