### PR TITLE
Sort Cargo.toml entries.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 members=[
+    "ykcompile",
     "ykpack",
     "ykrt",
     "yktrace",
-    "ykcompile",
     "ykview",
 ]
 

--- a/ykcompile/Cargo.toml
+++ b/ykcompile/Cargo.toml
@@ -8,12 +8,12 @@ license = "Apache-2.0 OR MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yktrace = { path = "../yktrace" }
-ykpack = { path = "../ykpack" }
 dynasmrt = "1.0.0"
 hex = "0.4.2"
-libc = "0.2.80"
 lazy_static = "1.4.0"
+libc = "0.2.80"
+ykpack = { path = "../ykpack" }
+yktrace = { path = "../yktrace" }
 
 [build-dependencies]
 cc = "1.0.62"

--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-serde = { version = "1.0.115", features = ["derive"] }
-fallible-iterator = "0.2.0"
 bincode = "1.3.1"
+fallible-iterator = "0.2.0"
+serde = { version = "1.0.115", features = ["derive"] }

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-libc = "0.2.80"
 fallible-iterator = "0.2.0"
-ykpack = { path = "../ykpack" }
-lazy_static = "1.4.0"
-hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
-phdrs = { git = "https://github.com/softdevteam/phdrs" }
-gimli = "0.23.0"
-object = "0.22.0"
-memmap = "0.7.0"
 fxhash = "0.2.1"
+gimli = "0.23.0"
+hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
+lazy_static = "1.4.0"
+libc = "0.2.80"
+memmap = "0.7.0"
+object = "0.22.0"
+phdrs = { git = "https://github.com/softdevteam/phdrs" }
+ykpack = { path = "../ykpack" }
 
 [dev-dependencies]
 fm = "0.1.4"


### PR DESCRIPTION
In my experience it's easier to do things like updating dependencies if the entries are sorted alphabetically.