### PR TITLE
Force codegen-units=1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members=[
 ]
 
 [profile.dev]
+codegen-units = 1
 panic = "abort"


### PR DESCRIPTION
Higher "codegen-units" (in theory at least) improve compile time, but do so at the expense of duplicating compilation. In our case, this means we end up with duplicate SIR elements.

As a rough proxy, I measured how many duplicate elements we end up with in this repository while doing "cargo build --tests":

```
  codegen-units    % of duplicated MIR elements
  0 [i.e. "inf"]   2.93%
  1                0.28%
  2                1.15%
  3                1.62%
```

I couldn't measure any time difference for a fresh "cargo build --tests" between codegen-units={0,1,3}. I'm not sure why.