### PR TITLE
Implement lazy SIR loading.

### DIFF
--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -729,7 +729,8 @@ impl<TT> TraceCompiler<TT> {
             // If it is a checked operation, then we have to build a (value, overflow-flag) tuple.
             // Let's do the flag first, so as to read EFLAGS closest to where they are set.
             let dest_ro = dest_loc.unwrap_mem();
-            let tty = SIR.ty(&dest.ty()).unwrap_tuple();
+            let sir_ty = SIR.ty(&dest.ty());
+            let tty = sir_ty.unwrap_tuple();
             let flag_off = i32::try_from(tty.fields.offsets[1]).unwrap();
 
             if opnd1_ty.is_signed_int() {
@@ -984,7 +985,7 @@ impl<TT> TraceCompiler<TT> {
         let ty = SIR.ty(&src.ty()); // Type of the source.
         let cty = SIR.ty(&dest.ty()); // Type of the cast (same as dest type).
         match ty {
-            Ty::UnsignedInt(_) => self.c_cast_uint(src_loc, &ty, cty),
+            Ty::UnsignedInt(_) => self.c_cast_uint(src_loc, &ty, &cty),
             _ => todo!(),
         }
         let dest_loc = self.iplace_to_location(dest);

--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -9,4 +9,5 @@ license = "Apache-2.0 OR MIT"
 bincode = "1.3.1"
 bitflags = "1.2"
 fallible-iterator = "0.2.0"
+fxhash = "0.2.1"
 serde = { version = "1.0.115", features = ["derive"] }

--- a/ykpack/src/encode.rs
+++ b/ykpack/src/encode.rs
@@ -1,35 +1,23 @@
 use crate::Pack;
-use std::io::Write;
 
 /// The pack encoder.
-///
-/// Packs are written using the `serialise()` method. Once all of the desired packs is serialised,
-/// the consumer must call `done()`.
 pub struct Encoder<'a> {
-    to: &'a mut dyn Write,
-    done: bool,
+    to: &'a mut Vec<u8>,
 }
 
 impl<'a> Encoder<'a> {
     /// Creates a new encoder which serialises `Pack` into the writable `write_into`.
-    pub fn from(write_into: &'a mut dyn Write) -> Self {
-        Self {
-            to: write_into,
-            done: false,
-        }
+    pub fn from(write_into: &'a mut Vec<u8>) -> Self {
+        Self { to: write_into }
     }
 
     /// Serialises a pack.
     pub fn serialise(&mut self, md: Pack) -> Result<(), bincode::Error> {
-        assert!(!self.done);
         bincode::serialize_into(&mut *self.to, &Some(md))
     }
 
-    /// Finalises the serialisation and writes a sentinel.
-    pub fn done(mut self) -> Result<(), bincode::Error> {
-        assert!(!self.done);
-        bincode::serialize_into(&mut *self.to, &None::<Pack>)?;
-        self.done = true;
-        Ok(())
+    /// Return the number of bytes encoded so far.
+    pub fn tell(&mut self) -> usize {
+        self.to.len()
     }
 }

--- a/ykview/Cargo.toml
+++ b/ykview/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
+memmap = "0.7.0"
 ykpack = { path = "../ykpack" }
 yktrace = { path = "../yktrace" }


### PR DESCRIPTION
Companion PR ~~soon~~ https://github.com/softdevteam/ykrustc/pull/149.

Currently we load all of the SIR into memory the first time we request a
type or a body. By doing so we incur a large (one-time) cost, even if we
don't use 99% of the loaded SIR.

This change implements lazy loading. Each SIR section now starts with a
header which serves as a table of contents, mapping type and body
identifiers to their byte offsets within the section. This gives us
random access to the contents of the SIR, which is both faster and more
memory efficient.

This first version is naive in that it implements no caching (of types,
bodies, or any of the associated decoding mechanisms). It can surely be
optimised further (but later).

Rough benchmarking of a full test suite run before and after this
change:

```
              Mean        Std.Dev.    Min         Median      Max
Before:
  real        30.643      0.325       30.246      30.638      31.245
  user        127.624     0.931       126.417     127.238     129.612
  sys         5.106       0.680       3.925       5.270       6.062
After:
  real        22.399      0.614       21.910      22.159      24.056
  user        131.255     0.653       129.918     131.371     132.273
  sys         4.981       0.742       4.145       4.953       6.603
```

The next-most-costly part of the system is now dwarf stuff.