### PR TITLE
Audit mt.rs

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -299,7 +299,7 @@ impl MTThread {
                     let bct = unsafe { Box::from_raw(ptr as *mut CompiledTrace<I>) };
                     let tptr = bct.ptr();
                     let func: fn(&mut I) -> bool = unsafe { mem::transmute(tptr) };
-                    let _raw = Box::into_raw(bct);
+                    mem::forget(bct);
                     return Some(func);
                 }
                 _ => unreachable!(),

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -244,6 +244,10 @@ impl MTThread {
                             Rc::get_mut(&mut self.inner).unwrap().tracer =
                                 Some((start_tracing(self.inner.tracing_kind), loc_id));
                             return None;
+                        } else {
+                            // We raced with another thread that's also trying to trace this
+                            // Location, so free the malloc'd block.
+                            unsafe { Box::from_raw(loc_id) };
                         }
                     } else {
                         let new_pack = PHASE_COUNTING | ((count + 1) << PHASE_NUM_BITS);

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -228,10 +228,10 @@ impl MTThread {
         loop {
             // We need Acquire ordering, as PHASE_COMPILED will need to read information written to
             // external data as a result of the PHASE_TRACING -> PHASE_COMPILED transition.
-            let lp = loc.pack.load(Ordering::Acquire);
+            let mut lp = loc.pack.load(Ordering::Acquire);
             match lp & PHASE_TAG {
                 PHASE_COUNTING => {
-                    let count = (lp & !PHASE_TAG) >> 2;
+                    let mut count = (lp & !PHASE_TAG) >> 2;
                     if count >= self.inner.hot_threshold {
                         if self.inner.tracer.is_some() {
                             // This thread is already tracing. Note that we don't increment the hot
@@ -250,9 +250,18 @@ impl MTThread {
                             unsafe { Box::from_raw(loc_id) };
                         }
                     } else {
-                        let new_pack = PHASE_COUNTING | ((count + 1) << PHASE_NUM_BITS);
-                        if loc.pack.compare_and_swap(lp, new_pack, Ordering::Release) == lp {
-                            return None;
+                        loop {
+                            let new_pack = PHASE_COUNTING | ((count + 1) << PHASE_NUM_BITS);
+                            if loc.pack.compare_and_swap(lp, new_pack, Ordering::Release) == lp {
+                                return None;
+                            }
+                            // We raced with another thread, but we'd still like to try
+                            // incrementing the count if possible, so we try again.
+                            lp = loc.pack.load(Ordering::Acquire);
+                            count = (lp & !PHASE_TAG) >> 2;
+                            if count >= self.inner.hot_threshold {
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR audits `mt.rs` for issues. Most are fairly harmless bugs (https://github.com/softdevteam/yk/commit/f455452a34857079c109d6fc36780d7820164268, https://github.com/softdevteam/yk/commit/56d0156bb33c3fb79e0785799c017515d8883e11) but https://github.com/softdevteam/yk/commit/b58b6bb5c63185dd5be574bfbbba4183a1e184e9 is, I think, a biggy.

However, with that change our tests now fail, so something else is going on.