### PR TITLE
Stop the PT tracer, when HWTTacer is dropped.

### DIFF
--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -38,6 +38,14 @@ impl ThreadTracerImpl for HWTThreadTracer {
     }
 }
 
+impl Drop for HWTThreadTracer {
+    fn drop(&mut self) {
+        // If we haven't stopped the tracer yet, do it now. This might return an error if the
+        // tracer was already stopped, but we don't care as long as it's stopped.
+        let _ = self.ttracer.stop_tracing();
+    }
+}
+
 pub fn start_tracing() -> ThreadTracer {
     let tracer = TracerBuilder::new().build().unwrap();
     let mut ttracer = (*tracer).thread_tracer();


### PR DESCRIPTION
It's possible for the hardware tracer to be dropped while it is still
tracing, leaving the PT tracer running. This can cause issues with other
threads wanting to trace. Calling `stop_tracing` on the PT tracer when
the hardware tracer is dropped fixes this.