### PR TITLE
Use an interval tree for SIR labels.

### DIFF
--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -11,6 +11,7 @@ fallible-iterator = "0.2.0"
 fxhash = "0.2.1"
 gimli = "0.23.0"
 hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
+intervaltree = "0.2"
 lazy_static = "1.4.0"
 libc = "0.2.80"
 memmap = "0.7.0"

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -3,8 +3,9 @@ use phdrs::objects;
 
 use crate::sir::SirLoc;
 use hwtracer::{HWTracerError, Trace};
+use intervaltree::IntervalTree;
 use lazy_static::lazy_static;
-use std::{convert::TryFrom, env, fs};
+use std::{convert::TryFrom, env, fs, iter::FromIterator};
 use ykpack::SirLabel;
 
 lazy_static! {
@@ -17,7 +18,7 @@ lazy_static! {
     /// to be a lazy static, loaded only once and shared.
     ///
     /// FIXME if we want to support dlopen(), we will have to rethink this.
-    static ref LABELS: Vec<SirLabel> = load_labels();
+    static ref LABELS: IntervalTree<usize, SirLabel> = load_labels();
 }
 
 pub struct HWTMapper {
@@ -31,7 +32,11 @@ impl HWTMapper {
     }
 
     /// Maps each entry of a hardware trace to the appropriate SirLoc.
-    pub fn map(&self, trace: Box<dyn Trace>) -> Result<Vec<SirLoc>, HWTracerError> {
+    ///
+    /// For each block in the trace, the interval tree is queried for labels coinciding with the
+    /// block. Label addresses which coincide are therefore contained within the block, and are
+    /// thus part of the SIR trace.
+    pub fn map_trace(&self, trace: Box<dyn Trace>) -> Result<Vec<SirLoc>, HWTracerError> {
         let mut annotrace = Vec::new();
         for block in trace.iter_blocks() {
             let block = block?;
@@ -47,25 +52,20 @@ impl HWTMapper {
             //
             // b) `labels` is sorted, so the blocks will be appended to the trace in the
             // correct order.
-            let mut locs = Vec::new();
-            for lbl in &*LABELS {
-                if lbl.off >= start_addr && lbl.off <= end_addr {
-                    // Found matching label.
-                    // Store the virtual address alongside the first basic block, so we can turn
-                    // inlined functions into calls during tracing.
+            let mut locs = LABELS
+                .query(start_addr..(end_addr + 1))
+                .map(|e| {
+                    let lbl = &e.value;
                     let vaddr = if lbl.bb == 0 {
                         Some(block.first_instr())
                     } else {
                         None
                     };
-                    locs.push(SirLoc::new(lbl.symbol_name.clone(), lbl.bb, vaddr));
-                } else if lbl.off > end_addr {
-                    // `labels` is sorted by address, so once we see one with an address
-                    // higher than `end_addr`, we know there can be no further hits.
-                    break;
-                }
-            }
-            annotrace.extend(locs);
+                    (lbl.off, SirLoc::new(lbl.symbol_name.clone(), lbl.bb, vaddr))
+                })
+                .collect::<Vec<_>>();
+            locs.sort_by_key(|l| l.0);
+            annotrace.extend(locs.into_iter().map(|l| l.1));
         }
         Ok(annotrace)
     }
@@ -79,13 +79,14 @@ fn get_phdr_offset() -> u64 {
 
 /// Loads SIR location labels from the executable.
 ///
-/// The returned vector is sorted by label address ascending (due to the encode ordering).
-fn load_labels() -> Vec<SirLabel> {
+/// We load the labels into an interval tree for fast queries later. Each label address is stored
+/// in the tree as a "point interval" (an interval with only one member, e.g. `0..1`).
+fn load_labels() -> IntervalTree<usize, SirLabel> {
     let pathb = env::current_exe().unwrap();
     let file = fs::File::open(&pathb.as_path()).unwrap();
     let mmap = unsafe { memmap::Mmap::map(&file).unwrap() };
     let object = object::File::parse(&*mmap).unwrap();
     let sec = object.section_by_name(ykpack::YKLABELS_SECTION).unwrap();
-    let ret = bincode::deserialize::<Vec<SirLabel>>(sec.data().unwrap()).unwrap();
-    ret
+    let vec = bincode::deserialize::<Vec<SirLabel>>(sec.data().unwrap()).unwrap();
+    IntervalTree::from_iter(vec.into_iter().map(|l| (l.off..(l.off + 1), l)))
 }

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -32,7 +32,7 @@ impl ThreadTracerImpl for HWTThreadTracer {
     fn stop_tracing(&mut self) -> Result<Box<dyn SirTrace>, InvalidTraceError> {
         let hwtrace = self.ttracer.stop_tracing().unwrap();
         let mt = HWTMapper::new();
-        mt.map(hwtrace)
+        mt.map_trace(hwtrace)
             .map_err(|_| InvalidTraceError::InternalError)
             .map(|sirtrace| Box::new(HWTSirTrace { sirtrace }) as Box<dyn SirTrace>)
     }


### PR DESCRIPTION
To make a SIR trace, there's a "mapping" stage which translates PT virtual addresses to SIR locations. Before this change, for each block libipt gave us we had to do a linear search over a list of label addresses, searching for those that coincide. That was slow.

This change puts the labels in a data structure better suited: an interval tree. Then computing the coinciding intervals can be done in log time, rather than linear time.

Rough benchmarking of test suite:

before:
```
1: cargo test
            Mean        Std.Dev.    Min         Median      Max
real        9.363       0.104       9.237       9.395       9.480
user        98.112      0.361       97.681      98.081      98.720
sys         6.037       0.553       5.157       6.012       6.804
```

after:
```
            Mean        Std.Dev.    Min         Median      Max
real        4.574       0.177       4.310       4.543       4.794
user        19.170      0.180       18.889      19.195      19.382
sys         9.995       0.273       9.666       9.997       10.446
```