### PR TITLE
Body and type caches

### DIFF
--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -408,7 +408,7 @@ impl<TT> TraceCompiler<TT> {
         }
 
         // FIXME: optimisation: small structs and tuples etc. could actually live in a register.
-        let ty = SIR.ty(&decl.ty);
+        let ty = &*SIR.ty(&decl.ty);
         match ty {
             Ty::UnsignedInt(ui) => !matches!(ui, UnsignedIntTy::U128),
             Ty::SignedInt(si) => !matches!(si, SignedIntTy::I128),
@@ -982,7 +982,7 @@ impl<TT> TraceCompiler<TT> {
 
     fn c_cast(&mut self, dest: &IPlace, src: &IPlace) {
         let src_loc = self.iplace_to_location(src);
-        let ty = SIR.ty(&src.ty()); // Type of the source.
+        let ty = &*SIR.ty(&src.ty()); // Type of the source.
         let cty = SIR.ty(&dest.ty()); // Type of the cast (same as dest type).
         match ty {
             Ty::UnsignedInt(_) => self.c_cast_uint(src_loc, &ty, &cty),

--- a/yktrace/src/sir.rs
+++ b/yktrace/src/sir.rs
@@ -13,7 +13,7 @@ use std::{
     iter::Iterator,
     sync::{Arc, RwLock}
 };
-use ykpack::{self, Body, BodyFlags, CguHash, Decoder, Pack, SirHeader, SirOffset};
+use ykpack::{self, Body, BodyFlags, CguHash, Decoder, Pack, SirHeader, SirOffset, Ty};
 
 lazy_static! {
     pub static ref EXE_MMAP: Mmap =
@@ -36,7 +36,9 @@ pub struct Sir<'m> {
     /// Section cache to avoid expensive `object::File::section_by_name()` calls.
     sec_cache: FxHashMap<String, &'m [u8]>,
     /// Body cache, to avoid repeated decodings.
-    body_cache: RwLock<FxHashMap<String, Option<Arc<Body>>>>
+    body_cache: RwLock<FxHashMap<String, Option<Arc<Body>>>>,
+    /// Type cache, to avoid repeated decodings.
+    ty_cache: RwLock<FxHashMap<ykpack::TypeId, Arc<Ty>>>
 }
 
 impl<'m> Sir<'m> {
@@ -65,7 +67,8 @@ impl<'m> Sir<'m> {
             hdrs,
             exe_obj,
             sec_cache,
-            body_cache: Default::default()
+            body_cache: Default::default(),
+            ty_cache: Default::default()
         })
     }
 
@@ -87,11 +90,24 @@ impl<'m> Sir<'m> {
     }
 
     /// Get the type data for the given type ID.
-    pub fn ty(&self, tyid: &ykpack::TypeId) -> ykpack::Ty {
+    pub fn ty(&self, tyid: &ykpack::TypeId) -> Arc<ykpack::Ty> {
+        {
+            let rd = self.ty_cache.read().unwrap();
+            if let Some(ty) = rd.get(tyid) {
+                // Cache hit, return a reference to the previously decoded body.
+                return ty.clone();
+            }
+        } // Drop the RwLock's read() to prevent deadlocking.
+
+        // Cache miss. Decode the type and update the cache.
         let (cgu, tidx) = tyid;
         let (ref sec_name, ref hdr, hdr_size) = SIR.hdrs[cgu];
         let off = hdr.types[usize::try_from(*tidx).unwrap()];
-        self.decode_ty(sec_name, hdr_size + off)
+        let ty = self.decode_ty(sec_name, hdr_size + off);
+        let mut wr = self.ty_cache.write().unwrap();
+        let arc = Arc::new(ty);
+        wr.insert(tyid.to_owned(), arc.clone());
+        arc
     }
 
     /// Decode a body in a named section, at an absolute offset from the beginning of that section.


### PR DESCRIPTION
These changes implement body and type caching to avoid repeated SIR decodings.

Below are some measurements. It seems like body caching gives a decent speedup in single-threaded scenarios, but not in multi-threaded scenarios. Type caching however doesn't really offer much of an improvement (kill that commit?).

My guess as to why we don't win much in multi-threaded scenarios is that there's mad contention on the `RwLock` protecting the cache(s). There are also `Arc`s which are necessary to appease the borrow checker.

One idea would be to use a concurrent hashmap library like [this](https://crates.io/crates/dashmap) or [this](https://crates.io/crates/storage-map). The latter takes advantage of the map being monotonic (in the sense that keys are only ever added), which fits our use case (for now).

For now raising this as a draft for discussion.

## Before

Single test thread:
```
            Mean        Std.Dev.    Min         Median      Max
real        7.122       0.039       7.072       7.125       7.208
user        7.166       0.065       7.058       7.175       7.247
sys         1.051       0.055       0.969       1.051       1.139
```

Many test threads:
```
            Mean        Std.Dev.    Min         Median      Max
real        3.656       0.147       3.432       3.747       3.798
user        12.089      0.248       11.765      11.998      12.563
sys         6.247       0.580       5.451       6.220       7.211
```

## Only Body Cache

Single test thread:
```
            Mean        Std.Dev.    Min         Median      Max
real        3.452       0.037       3.396       3.462       3.519
user        2.949       0.042       2.876       2.943       3.024
sys         0.770       0.050       0.691       0.778       0.863
```

Many test threads:
```
            Mean        Std.Dev.    Min         Median      Max
real        2.861       0.057       2.782       2.856       2.959
user        6.453       0.104       6.329       6.463       6.640
sys         6.046       0.405       5.414       6.079       6.652
```

## Both Caches

Single test thread:
```
            Mean        Std.Dev.    Min         Median      Max
real        3.470       0.029       3.407       3.473       3.511
user        2.984       0.036       2.911       2.990       3.034
sys         0.754       0.042       0.710       0.742       0.823
```

Many test threads:
```
            Mean        Std.Dev.    Min         Median      Max
real        2.931       0.049       2.862       2.927       2.999
user        6.304       0.149       6.117       6.278       6.660
sys         6.315       0.389       5.734       6.226       7.133
```
