### PR TITLE
Drop the `test_` prefix on test names.

### DIFF
--- a/ykbh/src/lib.rs
+++ b/ykbh/src/lib.rs
@@ -298,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn test_simple() {
+    fn simple() {
         struct IO(u8, u8);
         #[no_mangle]
         fn simple(io: &mut IO) {
@@ -311,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tuple() {
+    fn tuple() {
         struct IO((u8, u8, u8));
         #[no_mangle]
         fn func_tuple(io: &mut IO) {
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref() {
+    fn reference() {
         struct IO(u8, u8);
         #[no_mangle]
         fn func_ref(io: &mut IO) {
@@ -341,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tupleref() {
+    fn tupleref() {
         struct IO((u8, u8));
         #[no_mangle]
         fn func_tupleref(io: &mut IO) {
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_doubleref() {
+    fn doubleref() {
         struct IO((u8, u8));
         #[no_mangle]
         fn func_doubleref(io: &mut IO) {
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn test_call() {
+    fn call() {
         struct IO(u8, u8);
 
         fn foo(i: u8) -> u8 {

--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -1798,7 +1798,7 @@ mod tests {
     }
 
     #[test]
-    fn test_simple() {
+    fn simple() {
         struct IO(u8);
 
         #[interp_step]
@@ -1880,7 +1880,7 @@ mod tests {
     }
 
     #[test]
-    fn test_function_call_simple() {
+    fn function_call_simple() {
         struct IO(u8);
 
         #[interp_step]
@@ -1902,7 +1902,7 @@ mod tests {
     }
 
     #[test]
-    fn test_function_call_nested() {
+    fn function_call_nested() {
         struct IO(u8);
 
         fn fnested3(i: u8, _j: u8) -> u8 {
@@ -2083,7 +2083,7 @@ mod tests {
 
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
-    fn test_spilling_simple() {
+    fn spilling_simple() {
         struct IO(u64);
 
         #[interp_step]
@@ -2113,7 +2113,7 @@ mod tests {
 
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
-    fn test_spilling_u64() {
+    fn spilling_u64() {
         struct IO(u64);
 
         fn u64value() -> u64 {
@@ -2150,7 +2150,7 @@ mod tests {
 
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
-    fn test_mov_register_to_stack() {
+    fn mov_register_to_stack() {
         struct IO(u8, u8);
 
         #[interp_step]
@@ -2180,7 +2180,7 @@ mod tests {
 
     #[ignore] // FIXME: It has become hard to test spilling.
     #[test]
-    fn test_mov_stack_to_register() {
+    fn mov_stack_to_register() {
         struct IO(u8);
 
         #[interp_step]
@@ -2238,7 +2238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_binop_add_simple() {
+    fn binop_add_simple() {
         #[derive(Eq, PartialEq, Debug)]
         struct IO(u64, u64, u64);
 
@@ -2259,7 +2259,7 @@ mod tests {
     }
 
     #[test]
-    fn test_binop_add_overflow() {
+    fn binop_add_overflow() {
         #[derive(Eq, PartialEq, Debug)]
         struct IO(u8, u8);
 
@@ -2287,7 +2287,7 @@ mod tests {
     }
 
     #[test]
-    fn test_binop_other() {
+    fn binop_other() {
         #[derive(Eq, PartialEq, Debug)]
         struct IO(u64, u64, u64);
 
@@ -2309,7 +2309,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_deref_simple() {
+    fn ref_deref_simple() {
         #[derive(Debug)]
         struct IO(u64);
 
@@ -2333,7 +2333,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_deref_double() {
+    fn ref_deref_double() {
         #[derive(Debug)]
         struct IO(u64);
 
@@ -2357,7 +2357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_deref_double_and_field() {
+    fn ref_deref_double_and_field() {
         #[derive(Debug)]
         struct IO(u64);
 
@@ -2381,7 +2381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_deref_stack() {
+    fn ref_deref_stack() {
         struct IO(u64);
 
         #[interp_step]
@@ -2412,7 +2412,7 @@ mod tests {
 
     /// Dereferences a variable that lives on the stack and stores it in a register.
     #[test]
-    fn test_deref_stack_to_register() {
+    fn deref_stack_to_register() {
         fn deref1(arg: u64) -> u64 {
             let a = &arg;
             return *a;
@@ -2440,7 +2440,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deref_register_to_stack() {
+    fn deref_register_to_stack() {
         struct IO(u64);
 
         fn deref2(arg: u64) -> u64 {
@@ -2470,7 +2470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_do_not_trace() {
+    fn do_not_trace() {
         struct IO(u8);
 
         #[do_not_trace]
@@ -2509,7 +2509,7 @@ mod tests {
     }
 
     #[test]
-    fn test_do_not_trace_stdlib() {
+    fn do_not_trace_stdlib() {
         struct IO<'a>(&'a mut Vec<u64>);
 
         #[interp_step]
@@ -2532,7 +2532,7 @@ mod tests {
     }
 
     #[test]
-    fn test_projection_chain() {
+    fn projection_chain() {
         #[derive(Debug)]
         struct IO((usize, u8, usize), u8, S, usize);
 
@@ -2568,7 +2568,7 @@ mod tests {
     }
 
     #[test]
-    fn test_projection_lhs() {
+    fn projection_lhs() {
         struct IO((u8, u8), u8);
 
         #[interp_step]
@@ -2590,7 +2590,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array() {
+    fn array() {
         struct IO<'a>(&'a mut [u8; 3], u8);
 
         #[interp_step]
@@ -2619,7 +2619,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_nested() {
+    fn array_nested() {
         struct IO<'a>(&'a mut [[u8; 3]; 2], u8);
 
         #[interp_step]
@@ -2644,7 +2644,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_nested_mad() {
+    fn array_nested_mad() {
         struct S([u16; 4]);
         struct IO<'a>(&'a mut [S; 3], u16);
 
@@ -2740,7 +2740,7 @@ mod tests {
 
     #[test]
     #[ignore] // FIXME Broken during new trimming scheme. Seg faults.
-    fn test_rvalue_len() {
+    fn rvalue_len() {
         struct IO<'a>(&'a [u8], u8);
 
         fn matchthis(inputs: &IO, pc: usize) -> u8 {
@@ -2798,7 +2798,7 @@ mod tests {
     }
 
     #[test]
-    fn test_comparison() {
+    fn comparison() {
         struct IO(u8, bool);
 
         fn checks(i: u8) -> bool {
@@ -2830,7 +2830,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guard() {
+    fn guard() {
         struct IO(u8, u8);
 
         fn guard(i: u8) -> u8 {
@@ -2864,7 +2864,7 @@ mod tests {
     }
 
     #[test]
-    fn test_match() {
+    fn matching() {
         struct IO(u8);
 
         #[interp_step]
@@ -2890,7 +2890,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cast() {
+    fn cast() {
         struct IO(u16, u8);
 
         #[interp_step]
@@ -2918,7 +2918,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_add() {
+    fn vec_add() {
         struct IO {
             ptr: usize,
             cells: Vec<u8>,

--- a/ykcompile/src/stack_builder.rs
+++ b/ykcompile/src/stack_builder.rs
@@ -40,7 +40,7 @@ mod tests {
     use super::StackBuilder;
 
     #[test]
-    fn test_stackbuilder() {
+    fn stackbuilder() {
         let mut sb = StackBuilder::default();
 
         assert_eq!(sb.alloc(8, 8).unwrap_mem().off, -8);

--- a/ykpack/src/lib.rs
+++ b/ykpack/src/lib.rs
@@ -83,7 +83,7 @@ mod tests {
 
     // Check a typical serialising and deserialising session.
     #[test]
-    fn test_basic() {
+    fn basic() {
         let inputs = get_sample_packs();
         let num_packs = inputs.len();
         let mut buf = Vec::new();

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -347,6 +347,7 @@ impl MTThread {
                         .0
                         .stop_tracing()
                         .unwrap();
+                    dbg!(sir_trace.raw_len());
 
                     // Start a compilation thread.
                     let (snd, rcv) = channel();

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -55,28 +55,28 @@ mod tests {
     const TRACING_KIND: TracingKind = TracingKind::HardwareTracing;
 
     #[test]
-    fn test_trace() {
-        test_helpers::test_trace(TRACING_KIND);
+    fn trace() {
+        test_helpers::trace(TRACING_KIND);
     }
 
     #[test]
-    fn test_trace_twice() {
-        test_helpers::test_trace_twice(TRACING_KIND);
+    fn trace_twice() {
+        test_helpers::trace_twice(TRACING_KIND);
     }
 
     #[test]
-    fn test_trace_concurrent() {
-        test_helpers::test_trace_concurrent(TRACING_KIND);
+    fn trace_concurrent() {
+        test_helpers::trace_concurrent(TRACING_KIND);
     }
 
     #[test]
     #[should_panic]
-    fn test_oob_trace_index() {
-        test_helpers::test_oob_trace_index(TRACING_KIND);
+    fn oob_trace_index() {
+        test_helpers::oob_trace_index(TRACING_KIND);
     }
 
     #[test]
-    fn test_in_bounds_trace_indices() {
-        test_helpers::test_in_bounds_trace_indices(TRACING_KIND);
+    fn in_bounds_trace_indices() {
+        test_helpers::in_bounds_trace_indices(TRACING_KIND);
     }
 }

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -117,7 +117,7 @@ mod test_helpers {
     struct WorkIO(usize);
 
     /// Test that basic tracing works.
-    pub(crate) fn test_trace(kind: TracingKind) {
+    pub(crate) fn trace(kind: TracingKind) {
         let mut th = start_tracing(kind);
         black_box(work(&mut WorkIO(10)));
         let trace = th.t_impl.stop_tracing().unwrap();
@@ -125,7 +125,7 @@ mod test_helpers {
     }
 
     /// Test that tracing twice sequentially in the same thread works.
-    pub(crate) fn test_trace_twice(kind: TracingKind) {
+    pub(crate) fn trace_twice(kind: TracingKind) {
         let mut th1 = start_tracing(kind);
         black_box(work(&mut WorkIO(10)));
         let trace1 = th1.t_impl.stop_tracing().unwrap();
@@ -138,7 +138,7 @@ mod test_helpers {
     }
 
     /// Test that tracing in different threads works.
-    pub(crate) fn test_trace_concurrent(kind: TracingKind) {
+    pub(crate) fn trace_concurrent(kind: TracingKind) {
         let thr = thread::spawn(move || {
             let mut th1 = start_tracing(kind);
             black_box(work(&mut WorkIO(10)));
@@ -156,7 +156,7 @@ mod test_helpers {
 
     /// Test that accessing an out of bounds index fails.
     /// Tests calling this should be marked `#[should_panic]`.
-    pub(crate) fn test_oob_trace_index(kind: TracingKind) {
+    pub(crate) fn oob_trace_index(kind: TracingKind) {
         // Construct a really short trace.
         let mut th = start_tracing(kind);
         // Empty trace -- no call to an interp_step.
@@ -165,7 +165,7 @@ mod test_helpers {
     }
 
     /// Test that accessing locations 0 through trace.raw_len() -1 does not panic.
-    pub(crate) fn test_in_bounds_trace_indices(kind: TracingKind) {
+    pub(crate) fn in_bounds_trace_indices(kind: TracingKind) {
         // Construct a really short trace.
         let mut th = start_tracing(kind);
         black_box(work(&mut WorkIO(10)));

--- a/yktrace/src/swt.rs
+++ b/yktrace/src/swt.rs
@@ -252,28 +252,28 @@ mod tests {
     const TRACING_KIND: TracingKind = TracingKind::SoftwareTracing;
 
     #[test]
-    fn test_trace() {
-        test_helpers::test_trace(TRACING_KIND);
+    fn trace() {
+        test_helpers::trace(TRACING_KIND);
     }
 
     #[test]
-    fn test_trace_twice() {
-        test_helpers::test_trace_twice(TRACING_KIND);
+    fn trace_twice() {
+        test_helpers::trace_twice(TRACING_KIND);
     }
 
     #[test]
-    fn test_trace_concurrent() {
-        test_helpers::test_trace_concurrent(TRACING_KIND);
+    fn trace_concurrent() {
+        test_helpers::trace_concurrent(TRACING_KIND);
     }
 
     #[test]
     #[should_panic]
-    fn test_oob_trace_index() {
-        test_helpers::test_oob_trace_index(TRACING_KIND);
+    fn oob_trace_index() {
+        test_helpers::oob_trace_index(TRACING_KIND);
     }
 
     #[test]
-    fn test_in_bounds_trace_indices() {
-        test_helpers::test_in_bounds_trace_indices(TRACING_KIND);
+    fn in_bounds_trace_indices() {
+        test_helpers::in_bounds_trace_indices(TRACING_KIND);
     }
 }


### PR DESCRIPTION
I've started reviewing the test suite, and I'll start with something very superficial: the `test_` prefix on our test function names.

This is something we've inherited from our time with pytest. It's not necessary in Rust, and it's obvious what's a test due to `#[test]`.