### PR TITLE
Explicitly mark MTThread as not Sendable/Syncable.

### DIFF
--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(integer_atomics)]
+#![feature(negative_impls)]
 #![feature(test)]
 
 pub mod mt;

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -188,6 +188,9 @@ pub struct MTThread {
     inner: Rc<MTThreadInner>,
 }
 
+impl !Send for MTThread {}
+impl !Sync for MTThread {}
+
 impl MTThread {
     /// Return a meta-tracer [`MT`](struct.MT.html) struct.
     pub fn mt(&self) -> &MT {


### PR DESCRIPTION
MTThread is our abstraction for "some part of the meta-tracer that is guaranteed to be local to this thread." We need to make sure that users can't accidentally write safe code where they transfer MTThread is transferred to another thread. At the moment that guarantee is, somewhat precariously, maintained by the fact that MTThread contains an Rc (which isn't Send or Sync) so users trying to transfer an MTThread get an error along these lines:

```
  error[E0277]: `Rc<MTThreadInner>` cannot be sent between threads safely
     --> ykrt/src/mt.rs:403:18
      |
  403 |                   .spawn(move |mut mtt2| {
      |  __________________^^^^^_-
      | |                  |
      | |                  `Rc<MTThreadInner>` cannot be sent between threads safely
  404 | |                     let mut io = DummyIO {};
  405 | |                     mtt.control_point(Some(&loc), dummy_step, &mut io);
  406 | |                     let c1 = loc.pack.load(Ordering::Relaxed);
  ...   |
  419 | |                     assert!(c2 > c1);
  420 | |                 })
      | |_________________- within this `[closure@ykrt/src/mt.rs:403:24: 420:18]`
      |
      = help: within `[closure@ykrt/src/mt.rs:403:24: 420:18]`, the trait `Send` is not implemented for `Rc<MTThreadInner>`
      = note: required because it appears within the type `MTThread`
      = note: required because it appears within the type `[closure@ykrt/src/mt.rs:403:24: 420:18]`
```

However it's a) not guaranteed that we'll always use an Rc inside b) the fact that MTThread isn't Send/Sync isn't made clear to the user.

This commit explicitly marks the struct in questions as !Send and !Sync. This explicitly documents to users that MTThread can't be transferred between threads as well as prevents us accidentally allowing this should we get rid of the inner Rc at some point. The error one gets with this commit is thus:

```
  error[E0277]: `MTThread` cannot be sent between threads safely
     --> ykrt/src/mt.rs:406:18
      |
  406 |                   .spawn(move |mut mtt2| {
      |  __________________^^^^^_-
      | |                  |
      | |                  `MTThread` cannot be sent between threads safely
  407 | |                     let mut io = DummyIO {};
  408 | |                     mtt.control_point(Some(&loc), dummy_step, &mut io);
  409 | |                     let c1 = loc.pack.load(Ordering::Relaxed);
  ...   |
  422 | |                     assert!(c2 > c1);
  423 | |                 })
      | |_________________- within this `[closure@ykrt/src/mt.rs:406:24: 423:18]`
      |
      = help: within `[closure@ykrt/src/mt.rs:406:24: 423:18]`, the trait `Send` is not implemented for `MTThread`
      = note: required because it appears within the type `[closure@ykrt/src/mt.rs:406:24: 423:18]`
```

Unfortunately negative trait markers aren't part of stable Rust, and there appear to be some fairly long-standing problems with their interaction with the rest of the type system that mean they're probably not going to be part of stable Rust in the near future. However, the use of !Send and !Sync is widespread throughout the standard library, so it seems likely that either these will be supported long-term, or, at worst, we'll be given a sensible migration path if they're not. I think turning on the required unstable flag is thus probably just about worth it. At the very least, it will prevent the future-me spending half an hour trying to remember whether we enforced MTThread not being transferable between threads!