### PR TITLE
Less exports

### DIFF
--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -286,14 +286,14 @@ impl<TT> CompiledTrace<TT> {
 
 /// Represents a memory location using a register and an offset.
 #[derive(Debug, Clone, PartialEq)]
-pub struct RegAndOffset {
+struct RegAndOffset {
     reg: u8,
     off: OffT,
 }
 
 /// Describes the location of the pointer in Location::Indirect.
 #[derive(Debug, Clone, PartialEq)]
-pub enum IndirectLoc {
+enum IndirectLoc {
     /// There's a pointer in this register.
     Reg(u8),
     /// There's a pointer in memory somewhere.
@@ -301,7 +301,7 @@ pub enum IndirectLoc {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Location {
+enum Location {
     /// A value in a register.
     Reg(u8),
     /// A statically known memory location relative to a register.
@@ -1844,7 +1844,7 @@ mod tests {
 
     /// Fuzzy matches the textual TIR for the trace `tt` with the pattern `ptn`.
     /// Duplicated from yktrace, since you can't share things inside #[cfg(test)] between crates.
-    pub fn assert_tir(ptn: &str, tt: &TirTrace) {
+    fn assert_tir(ptn: &str, tt: &TirTrace) {
         let ptn_re = Regex::new(r"%.+?\b").unwrap(); // Names are words prefixed with `%`.
         let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
         let matcher = FMBuilder::new(ptn)

--- a/ykcompile/src/stack_builder.rs
+++ b/ykcompile/src/stack_builder.rs
@@ -17,7 +17,7 @@ pub struct StackBuilder {
 impl StackBuilder {
     /// Allocate an object of given size and alignment on the stack, returning a `Location::Mem`
     /// describing the position of the allocation. The stack is assumed to grow down.
-    pub fn alloc(&mut self, size: u64, align: u64) -> Location {
+    pub(crate) fn alloc(&mut self, size: u64, align: u64) -> Location {
         self.align(align);
         self.stack_top += size;
         Location::new_mem(RBP.code(), -i32::try_from(self.stack_top).unwrap())
@@ -30,7 +30,7 @@ impl StackBuilder {
     }
 
     /// Total allocated stack size in bytes.
-    pub fn size(&self) -> u32 {
+    pub(crate) fn size(&self) -> u32 {
         self.stack_top.try_into().unwrap()
     }
 }

--- a/yktrace/src/errors.rs
+++ b/yktrace/src/errors.rs
@@ -12,7 +12,7 @@ pub enum InvalidTraceError {
 
 impl InvalidTraceError {
     /// A helper function to create a `InvalidTraceError::NoSir`.
-    pub fn no_sir(symbol_name: &str) -> Self {
+    pub(crate) fn no_sir(symbol_name: &str) -> Self {
         InvalidTraceError::NoSir(String::from(symbol_name))
     }
 }

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -26,7 +26,7 @@ pub struct HWTMapper {
 }
 
 impl HWTMapper {
-    pub fn new() -> HWTMapper {
+    pub(super) fn new() -> HWTMapper {
         let phdr_offset = get_phdr_offset();
         HWTMapper { phdr_offset }
     }
@@ -36,7 +36,7 @@ impl HWTMapper {
     /// For each block in the trace, the interval tree is queried for labels coinciding with the
     /// block. Label addresses which coincide are therefore contained within the block, and are
     /// thus part of the SIR trace.
-    pub fn map_trace(&self, trace: Box<dyn Trace>) -> Result<Vec<SirLoc>, HWTracerError> {
+    pub(super) fn map_trace(&self, trace: Box<dyn Trace>) -> Result<Vec<SirLoc>, HWTracerError> {
         let mut annotrace = Vec::new();
         for block in trace.iter_blocks() {
             let block = block?;

--- a/yktrace/src/hwt/mod.rs
+++ b/yktrace/src/hwt/mod.rs
@@ -48,7 +48,7 @@ impl Drop for HWTThreadTracer {
     }
 }
 
-pub fn start_tracing() -> ThreadTracer {
+pub(crate) fn start_tracing() -> ThreadTracer {
     let tracer = TracerBuilder::new().build().unwrap();
     let mut ttracer = (*tracer).thread_tracer();
     ttracer.start_tracing().expect("Failed to start tracer.");

--- a/yktrace/src/swt.rs
+++ b/yktrace/src/swt.rs
@@ -63,7 +63,7 @@ impl ThreadTracerImpl for SWTThreadTracer {
     }
 }
 
-pub fn start_tracing() -> ThreadTracer {
+pub(crate) fn start_tracing() -> ThreadTracer {
     unsafe {
         yk_swt_start_tracing_impl();
     }

--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -608,11 +608,11 @@ pub struct Guard {
 }
 
 impl Guard {
-    pub fn maybe_defined_locals(&self) -> Vec<Local> {
+    fn maybe_defined_locals(&self) -> Vec<Local> {
         Vec::new()
     }
 
-    pub fn used_locals(&self) -> Vec<Local> {
+    fn used_locals(&self) -> Vec<Local> {
         let mut ret = Vec::new();
         match &self.val {
             IPlace::Val { local, .. } => ret.push(*local),
@@ -698,7 +698,7 @@ impl TirOp {
         }
     }
 
-    pub fn used_locals(&self) -> Vec<Local> {
+    fn used_locals(&self) -> Vec<Local> {
         match &self {
             TirOp::Statement(stmt) => stmt.used_locals(),
             TirOp::Guard(guard) => guard.used_locals()
@@ -721,7 +721,7 @@ pub mod tests {
     use test::black_box;
 
     /// Fuzzy matches the textual TIR for the trace `tt` with the pattern `ptn`.
-    pub fn assert_tir(ptn: &str, tt: &TirTrace) {
+    fn assert_tir(ptn: &str, tt: &TirTrace) {
         let ptn_re = Regex::new(r"%.+?\b").unwrap(); // Names are words prefixed with `%`.
         let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
         let matcher = FMBuilder::new(ptn)


### PR DESCRIPTION
This reduces the api surface of ykcompile and yktrace. If any of the exports turn out to be necessary later on, they can be exported again.