### PR TITLE
Remove some spill tests

### DIFF
--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -1706,21 +1706,6 @@ impl<TT> TraceCompiler<TT> {
         buf
     }
 
-    #[cfg(test)]
-    fn test_compile(tt: TirTrace) -> (CompiledTrace<TT>, u32) {
-        // Changing the registers available to the register allocator affects the number of spills,
-        // and thus also some tests. To make sure we notice when this happens we also check the
-        // number of spills in those tests. We thus need a slightly different version of the
-        // `compile` function that provides this information to the test.
-        let tc = TraceCompiler::<TT>::_compile(tt);
-        let spills = tc.stack_builder.size();
-        let ct = CompiledTrace::<TT> {
-            mc: tc.finish(false),
-            _pd: PhantomData,
-        };
-        (ct, spills)
-    }
-
     /// Compile a TIR trace, returning executable code.
     pub fn compile(tt: TirTrace) -> CompiledTrace<TT> {
         let tc = TraceCompiler::<TT>::_compile(tt);
@@ -2271,103 +2256,6 @@ mod tests {
         TraceCompiler::<IO>::compile(tir_trace).execute(&mut args);
         assert_eq!(args.0, 7);
         assert_eq!(args.0, inputs.0);
-    }
-
-    #[ignore] // FIXME: It has become hard to test spilling.
-    #[test]
-    fn spilling_simple() {
-        struct IO(u64);
-
-        #[interp_step]
-        fn many_locals(io: &mut IO) {
-            let _a = 1;
-            let _b = 2;
-            let _c = 3;
-            let _d = 4;
-            let _e = 5;
-            let _f = 6;
-            let h = 7;
-            let _g = true;
-            io.0 = h;
-        }
-
-        let mut inputs = IO(0);
-        let th = start_tracing(TracingKind::HardwareTracing);
-        many_locals(&mut inputs);
-        let sir_trace = th.stop_tracing().unwrap();
-        let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
-        let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
-        let mut args = IO(0);
-        ct.execute(&mut args);
-        assert_eq!(args.0, 7);
-        assert_eq!(spills, 3); // Three u8s.
-    }
-
-    #[ignore] // FIXME: It has become hard to test spilling.
-    #[test]
-    fn spilling_u64() {
-        struct IO(u64);
-
-        fn u64value() -> u64 {
-            // We need an extra function here to avoid SIR optimising this by assigning assigning the
-            // constant directly to the return value (which is a register).
-            4294967296 + 8
-        }
-
-        #[inline(never)]
-        #[interp_step]
-        fn spill_u64(io: &mut IO) {
-            let _a = 1;
-            let _b = 2;
-            let _c = 3;
-            let _d = 4;
-            let _e = 5;
-            let _f = 6;
-            let _g = 7;
-            let h: u64 = u64value();
-            io.0 = h;
-        }
-
-        let mut inputs = IO(0);
-        let th = start_tracing(TracingKind::HardwareTracing);
-        spill_u64(&mut inputs);
-        let sir_trace = th.stop_tracing().unwrap();
-        let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
-        let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
-        let mut args = IO(0);
-        ct.execute(&mut args);
-        assert_eq!(args.0, 4294967296 + 8);
-        assert_eq!(spills, 2 * 8);
-    }
-
-    #[ignore] // FIXME: It has become hard to test spilling.
-    #[test]
-    fn mov_register_to_stack() {
-        struct IO(u8, u8);
-
-        #[interp_step]
-        fn register_to_stack(io: &mut IO) {
-            let _a = 1;
-            let _b = 2;
-            let _c = 3;
-            let _d = 4;
-            let _e = 5;
-            let _f = 6;
-            let _g = 7;
-            let h = io.0;
-            io.1 = h;
-        }
-
-        let mut inputs = IO(8, 0);
-        let th = start_tracing(TracingKind::HardwareTracing);
-        register_to_stack(&mut inputs);
-        let sir_trace = th.stop_tracing().unwrap();
-        let tir_trace = TirTrace::new(&*SIR, &*sir_trace).unwrap();
-        let (ct, spills) = TraceCompiler::<IO>::test_compile(tir_trace);
-        let mut args = IO(8, 0);
-        ct.execute(&mut args);
-        assert_eq!(args.1, inputs.1);
-        assert_eq!(spills, 9); // f, g: i32, h:  u8.
     }
 
     #[test]


### PR DESCRIPTION
I spent some time trying to salvage these tests, but alas, it didn't work out.

See commit messages for detailed commentary.

Assigning to @ptersilie as he's familiar with this part of the system.

CC @ltratt