### PR TITLE
Encapsulate tracing state bit manipulation

### DIFF
--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -533,7 +533,6 @@ impl MTThread {
                 let new_state = State::phase_compiling(mtx);
                 loc.store(new_state, Ordering::Release);
 
-                Rc::get_mut(&mut self.inner).unwrap().tracer = None;
                 return None;
             }
             PHASE_COMPILING => {


### PR DESCRIPTION
This also replaces some `Box::from_raw`/`Arc::from_raw` calls followed by a `mem::forget` after using the result by simply turning the raw pointers into references. Both `Box::into_raw` and `Arc::into_raw` return a pointer that points directly to the stored value. For `Arc::into_raw` this means that it points just after the reference counters.