### PR TITLE
Remove Terminator::DropAndReplace

### DIFF
--- a/ykpack/src/types.rs
+++ b/ykpack/src/types.rs
@@ -836,11 +836,6 @@ pub enum Terminator {
         location: IPlace,
         target_bb: BasicBlockIndex,
     },
-    DropAndReplace {
-        location: IPlace,
-        target_bb: BasicBlockIndex,
-        value: IPlace,
-    },
     Call {
         operand: CallOperand,
         args: Vec<IPlace>,
@@ -893,15 +888,6 @@ impl Display for Terminator {
                 location,
                 target_bb,
             } => write!(f, "drop {}, bb{}", target_bb, location,),
-            Terminator::DropAndReplace {
-                location,
-                value,
-                target_bb,
-            } => write!(
-                f,
-                "drop_and_replace {}, {}, bb{}",
-                location, value, target_bb,
-            ),
             Terminator::Call {
                 operand,
                 args,

--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -331,7 +331,6 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                 Terminator::Goto(_)
                 | Terminator::Return
                 | Terminator::Drop { .. }
-                | Terminator::DropAndReplace { .. }
                 | Terminator::Call { .. }
                 | Terminator::Unimplemented(_) => None,
                 Terminator::Unreachable => panic!("Traced unreachable code"),


### PR DESCRIPTION
It wasn't used and never will as MIR lowers DropAndReplace before it reaches codegen.

Ykrustc PR: softdevteam/ykrustc#158