### PR TITLE
Use a C abi interface between ykrt and the rest of yorick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members=[
     "ykcompile",
     "ykpack",
     "ykrt",
+    "ykrt_internal",
     "yktrace",
     "ykview",
     "ykbh",

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-yktrace = { path = "../yktrace" }
-ykcompile = { path = "../ykcompile" }
+ykrt_internal = { path = "../ykrt_internal" }

--- a/ykrt/src/internal.rs
+++ b/ykrt/src/internal.rs
@@ -1,0 +1,43 @@
+use yktrace::sir::{SirTrace, SIR};
+use yktrace::tir::TirTrace;
+use yktrace::InvalidTraceError;
+
+/// The different ways by which we can collect a trace.
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum TracingKind {
+    /// Software tracing via ykrustc.
+    SoftwareTracing = 0,
+    /// Hardware tracing via ykrustc + hwtracer.
+    HardwareTracing = 1,
+}
+
+#[repr(C)]
+pub(crate) struct ThreadTracer(yktrace::ThreadTracer);
+
+impl ThreadTracer {
+    pub(crate) fn stop_tracing(self) -> Result<SirTrace, InvalidTraceError> {
+        self.0.stop_tracing()
+    }
+}
+
+pub(crate) fn start_tracing(tracing_kind: TracingKind) -> ThreadTracer {
+    ThreadTracer(yktrace::start_tracing(match tracing_kind {
+        TracingKind::SoftwareTracing => yktrace::TracingKind::SoftwareTracing,
+        TracingKind::HardwareTracing => yktrace::TracingKind::HardwareTracing,
+    }))
+}
+
+#[repr(C)]
+pub(crate) struct CompiledTrace<I>(ykcompile::CompiledTrace<I>);
+
+impl<I> CompiledTrace<I> {
+    pub(crate) fn ptr(&self) -> *const u8 {
+        self.0.ptr()
+    }
+}
+
+pub(crate) fn compile_trace<T>(sir_trace: SirTrace) -> CompiledTrace<T> {
+    let tt = TirTrace::new(&*SIR, &sir_trace).unwrap();
+    CompiledTrace(ykcompile::compile_trace(tt))
+}

--- a/ykrt/src/internal.rs
+++ b/ykrt/src/internal.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use yktrace::sir::{SirTrace, SIR};
 use yktrace::tir::TirTrace;
 use yktrace::InvalidTraceError;
@@ -29,15 +31,21 @@ pub(crate) fn start_tracing(tracing_kind: TracingKind) -> ThreadTracer {
 }
 
 #[repr(C)]
-pub(crate) struct CompiledTrace<I>(ykcompile::CompiledTrace<I>);
+pub(crate) struct CompiledTrace<I> {
+    compiled: ykcompile::CompiledTrace,
+    _marker: PhantomData<I>,
+}
 
 impl<I> CompiledTrace<I> {
     pub(crate) fn ptr(&self) -> *const u8 {
-        self.0.ptr()
+        self.compiled.ptr()
     }
 }
 
 pub(crate) fn compile_trace<T>(sir_trace: SirTrace) -> CompiledTrace<T> {
     let tt = TirTrace::new(&*SIR, &sir_trace).unwrap();
-    CompiledTrace(ykcompile::compile_trace(tt))
+    CompiledTrace {
+        compiled: ykcompile::compile_trace(tt),
+        _marker: PhantomData,
+    }
 }

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(test, feature(test))]
 
+mod internal;
 mod location;
 pub mod mt;
 

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -6,8 +6,7 @@ use std::{
     },
 };
 
-use ykcompile::CompiledTrace;
-
+use crate::internal::CompiledTrace;
 use crate::mt::ThreadIdInner;
 
 // The current meta-tracing phase of a given location in the end-user's code. Consists of a tag and

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -13,9 +13,7 @@ use std::{
     thread::{self, yield_now, JoinHandle},
 };
 
-use ykcompile::{compile_trace, CompiledTrace};
-use yktrace::{sir::SIR, start_tracing, tir::TirTrace, ThreadTracer, TracingKind};
-
+use crate::internal::{compile_trace, start_tracing, CompiledTrace, ThreadTracer, TracingKind};
 use crate::location::{
     CompilingTrace, Location, State, PHASE_COMPILED, PHASE_COMPILING, PHASE_COUNTING,
     PHASE_DONT_TRACE, PHASE_LOCKED, PHASE_TRACING, PHASE_TRACING_LOCK,
@@ -36,7 +34,10 @@ impl MTBuilder {
     pub fn new() -> Self {
         Self {
             hot_threshold: DEFAULT_HOT_THRESHOLD,
-            tracing_kind: TracingKind::default(),
+            #[cfg(tracermode = "hw")]
+            tracing_kind: TracingKind::HardwareTracing,
+            #[cfg(tracermode = "sw")]
+            tracing_kind: TracingKind::SoftwareTracing,
         }
     }
 
@@ -362,8 +363,7 @@ impl MTThread {
                 let mtx = Arc::new(Mutex::new(None));
                 let mtx_cl = Arc::clone(&mtx);
                 thread::spawn(move || {
-                    let tir_trace = TirTrace::new(&*SIR, &sir_trace).unwrap();
-                    let compiled = compile_trace::<I>(tir_trace);
+                    let compiled = compile_trace::<I>(sir_trace);
                     *mtx_cl.lock().unwrap() = Some(Box::new(compiled));
                     // FIXME: although we've now put the compiled trace into the mutex, there's no
                     // guarantee that the Location for which we're compiling will ever be executed

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -356,13 +356,14 @@ impl MTThread {
                     .take()
                     .unwrap()
                     .0
-                    .stop_tracing();
+                    .stop_tracing()
+                    .unwrap();
 
                 // Start a compilation thread.
                 let mtx = Arc::new(Mutex::new(None));
                 let mtx_cl = Arc::clone(&mtx);
                 thread::spawn(move || {
-                    let compiled = compile_trace::<I>(sir_trace);
+                    let compiled = compile_trace::<I>(sir_trace).unwrap();
                     *mtx_cl.lock().unwrap() = Some(Box::new(compiled));
                     // FIXME: although we've now put the compiled trace into the mutex, there's no
                     // guarantee that the Location for which we're compiling will ever be executed

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -356,8 +356,7 @@ impl MTThread {
                     .take()
                     .unwrap()
                     .0
-                    .stop_tracing()
-                    .unwrap();
+                    .stop_tracing();
 
                 // Start a compilation thread.
                 let mtx = Arc::new(Mutex::new(None));

--- a/ykrt_internal/Cargo.toml
+++ b/ykrt_internal/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ykrt_internal"
+version = "0.1.0"
+authors = ["bjorn3 <bjorn3@users.noreply.github.com>"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+yktrace = { path = "../yktrace" }
+ykcompile = { path = "../ykcompile" }

--- a/ykrt_internal/src/lib.rs
+++ b/ykrt_internal/src/lib.rs
@@ -1,0 +1,53 @@
+use std::ffi::c_void;
+
+use ykcompile::CompiledTrace;
+use yktrace::sir::{SirTrace, SIR};
+use yktrace::tir::TirTrace;
+
+/// The different ways by which we can collect a trace.
+#[derive(Clone, Copy)]
+#[repr(u8)]
+#[allow(dead_code)]
+enum TracingKind {
+    /// Software tracing via ykrustc.
+    SoftwareTracing = 0,
+    /// Hardware tracing via ykrustc + hwtracer.
+    HardwareTracing = 1,
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ykrt_start_tracing(tracing_kind: u8) -> *mut c_void {
+    Box::into_raw(Box::new(yktrace::start_tracing(match tracing_kind {
+        0 => yktrace::TracingKind::SoftwareTracing,
+        1 => yktrace::TracingKind::HardwareTracing,
+        _ => std::process::abort(), // FIXME return error
+    }))) as *mut c_void
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ykrt_stop_tracing(tracer: *mut c_void) -> *mut c_void {
+    Box::into_raw(Box::new(
+        Box::from_raw(tracer as *mut yktrace::ThreadTracer)
+            .stop_tracing()
+            .unwrap_or_else(|_| {
+                std::process::abort(); // FIXME return error
+            }),
+    )) as *mut c_void
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ykrt_compile_trace(sir_trace: *mut c_void) -> *mut c_void {
+    let tt = TirTrace::new(&*SIR, &*Box::from_raw(sir_trace as *mut SirTrace)).unwrap();
+    Box::into_raw(Box::new(ykcompile::compile_trace(tt))) as *mut c_void
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ykrt_compiled_trace_get_ptr(compiled_trace: *const c_void) -> *const c_void {
+    let compiled_trace = &*(compiled_trace as *mut CompiledTrace);
+    compiled_trace.ptr() as *const c_void
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ykrt_compiled_trace_dealloc(compiled_trace: *mut c_void) {
+    Box::from_raw(compiled_trace as *mut CompiledTrace);
+}

--- a/ykrt_internal/src/lib.rs
+++ b/ykrt_internal/src/lib.rs
@@ -1,8 +1,18 @@
-use std::ffi::c_void;
+use std::ffi::{c_void, CString};
+use std::panic::UnwindSafe;
+use std::os::raw::c_char;
 
 use ykcompile::CompiledTrace;
 use yktrace::sir::{SirTrace, SIR};
 use yktrace::tir::TirTrace;
+
+fn handle_panic<T>(f: impl FnOnce() -> T + UnwindSafe) -> T {
+    std::panic::catch_unwind(|| f()).unwrap_or_else(|_| {
+        // It is not safe for panics to cross through the "C" abi.
+        // FIXME use "C unwind" as abi once it is implemented.
+        std::process::abort();
+    })
+}
 
 /// The different ways by which we can collect a trace.
 #[derive(Clone, Copy)]
@@ -17,28 +27,63 @@ enum TracingKind {
 
 #[no_mangle]
 unsafe extern "C" fn __ykrt_start_tracing(tracing_kind: u8) -> *mut c_void {
-    Box::into_raw(Box::new(yktrace::start_tracing(match tracing_kind {
-        0 => yktrace::TracingKind::SoftwareTracing,
-        1 => yktrace::TracingKind::HardwareTracing,
-        _ => std::process::abort(), // FIXME return error
-    }))) as *mut c_void
+    handle_panic(|| {
+        let tracing_kind = match tracing_kind {
+            0 => yktrace::TracingKind::SoftwareTracing,
+            1 => yktrace::TracingKind::HardwareTracing,
+            _ => return std::ptr::null_mut(),
+        };
+        let tracer = yktrace::start_tracing(tracing_kind);
+        Box::into_raw(Box::new(tracer)) as *mut c_void
+    })
 }
 
 #[no_mangle]
-unsafe extern "C" fn __ykrt_stop_tracing(tracer: *mut c_void) -> *mut c_void {
-    Box::into_raw(Box::new(
-        Box::from_raw(tracer as *mut yktrace::ThreadTracer)
-            .stop_tracing()
-            .unwrap_or_else(|_| {
-                std::process::abort(); // FIXME return error
-            }),
-    )) as *mut c_void
+unsafe extern "C" fn __ykrt_stop_tracing(
+    tracer: *mut c_void,
+    error_msg: *mut *mut c_char,
+) -> *mut c_void {
+    handle_panic(|| {
+        let tracer = Box::from_raw(tracer as *mut yktrace::ThreadTracer);
+        let sir_trace = tracer.stop_tracing();
+        match sir_trace {
+            Ok(sir_trace) => Box::into_raw(Box::new(sir_trace)) as *mut c_void,
+            Err(err) => {
+                *error_msg = CString::new(err.to_string())
+                    .unwrap_or_else(|err| {
+                        eprintln!("Stop tracing error {} contains a null byte", err);
+                        std::process::abort();
+                    })
+                    .into_raw();
+                std::ptr::null_mut()
+            }
+        }
+    })
 }
 
 #[no_mangle]
-unsafe extern "C" fn __ykrt_compile_trace(sir_trace: *mut c_void) -> *mut c_void {
-    let tt = TirTrace::new(&*SIR, &*Box::from_raw(sir_trace as *mut SirTrace)).unwrap();
-    Box::into_raw(Box::new(ykcompile::compile_trace(tt))) as *mut c_void
+unsafe extern "C" fn __ykrt_compile_trace(
+    sir_trace: *mut c_void,
+    error_msg: *mut *mut c_char,
+) -> *mut c_void {
+    handle_panic(|| {
+        let sir_trace = Box::from_raw(sir_trace as *mut SirTrace);
+
+        let tt = match TirTrace::new(&*SIR, &*sir_trace) {
+            Ok(tt) => tt,
+            Err(err) => {
+                *error_msg = CString::new(err.to_string())
+                    .unwrap_or_else(|err| {
+                        eprintln!("Tir compilation error {} contains a null byte", err);
+                        std::process::abort();
+                    })
+                    .into_raw();
+                return std::ptr::null_mut();
+            }
+        };
+        let compiled_trace = ykcompile::compile_trace(tt);
+        Box::into_raw(Box::new(compiled_trace)) as *mut c_void
+    })
 }
 
 #[no_mangle]
@@ -49,5 +94,5 @@ unsafe extern "C" fn __ykrt_compiled_trace_get_ptr(compiled_trace: *const c_void
 
 #[no_mangle]
 unsafe extern "C" fn __ykrt_compiled_trace_dealloc(compiled_trace: *mut c_void) {
-    Box::from_raw(compiled_trace as *mut CompiledTrace);
+    handle_panic(|| Box::from_raw(compiled_trace as *mut CompiledTrace));
 }

--- a/yktrace/src/lib.rs
+++ b/yktrace/src/lib.rs
@@ -18,7 +18,7 @@ mod hwt;
 #[cfg(tracermode = "sw")]
 mod swt;
 
-use errors::InvalidTraceError;
+pub use errors::InvalidTraceError;
 use sir::SirTrace;
 use ykpack::Local;
 


### PR DESCRIPTION
In the future this will make it possible to separately compile the internals of yorick with optimizations and without tracing support.