### PR TITLE
Remove Location::NotLive.

### DIFF
--- a/ykcompile/src/store.rs
+++ b/ykcompile/src/store.rs
@@ -405,7 +405,6 @@ impl<TT> TraceCompiler<TT> {
                     },
                 }
             }
-            (Location::NotLive, _) | (_, Location::NotLive) => unreachable!(),
             _ => todo!(),
         }
     }


### PR DESCRIPTION
TraceCompiler::variable_location_map keeps track of the register
allocation of local variables.

We currently use a Location::NotLive variant to express that an variable
is not live and thus has no allocation. But we can instead just not
store that key in the variable_location_map.

This has the upshot of not having to continually check for
Location::NotLive (which, if we have done things correctly, can't arise
anyway) when matching over a Location.