### PR TITLE
Update dependencies.

### DIFF
--- a/ykcompile/Cargo.toml
+++ b/ykcompile/Cargo.toml
@@ -8,16 +8,16 @@ license = "Apache-2.0 OR MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dynasmrt = "1.0.0"
+dynasmrt = "1.0.1"
 hex = "0.4.2"
 lazy_static = "1.4.0"
-libc = "0.2.80"
+libc = "0.2.82"
 ykpack = { path = "../ykpack" }
 yktrace = { path = "../yktrace" }
 
 [build-dependencies]
-cc = "1.0.62"
+cc = "1.0.66"
 
 [dev-dependencies]
-fm = "0.1.4"
-regex = "1.4.2"
+fm = "0.2.0"
+regex = "1.4.3"

--- a/ykcompile/src/lib.rs
+++ b/ykcompile/src/lib.rs
@@ -1445,7 +1445,7 @@ mod tests {
         let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
         let matcher = FMBuilder::new(ptn)
             .unwrap()
-            .name_matcher(Some((ptn_re, text_re)))
+            .name_matcher(ptn_re, text_re)
             .distinct_name_matching(true)
             .build()
             .unwrap();

--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 bincode = "1.3.1"
-bitflags = "1.2"
+bitflags = "1.2.1"
 fallible-iterator = "0.2.0"
 fxhash = "0.2.1"
-serde = { version = "1.0.115", features = ["derive"] }
+serde = { version = "1.0.119", features = ["derive"] }

--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -159,7 +159,11 @@ impl<I> Location<I> {
     }
 
     pub(crate) fn compare_and_swap(&self, current: State, new: State, order: Ordering) -> State {
-        State(self.state.compare_and_swap(current.0, new.0, order))
+        State(
+            self.state
+                .compare_exchange(current.0, new.0, order, Ordering::Relaxed)
+                .unwrap_or_else(|e| e),
+        )
     }
 
     pub(crate) fn store(&self, state: State, order: Ordering) {

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -14,7 +14,7 @@ hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
 intervaltree = "0.2.6"
 lazy_static = "1.4.0"
 libc = "0.2.82"
-memmap = "0.7.0"
+memmap2 = "0.2.0"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 ykpack = { path = "../ykpack" }
 

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -11,18 +11,18 @@ fallible-iterator = "0.2.0"
 fxhash = "0.2.1"
 gimli = "0.23.0"
 hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
-intervaltree = "0.2"
+intervaltree = "0.2.6"
 lazy_static = "1.4.0"
-libc = "0.2.80"
+libc = "0.2.82"
 memmap = "0.7.0"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 ykpack = { path = "../ykpack" }
 
 [dependencies.object]
-version = "0.22.0"
+version = "0.23.0"
 default-features = false
 features = ["read_core", "elf"]
 
 [dev-dependencies]
-fm = "0.1.4"
-regex = "1.4.2"
+fm = "0.2.0"
+regex = "1.4.3"

--- a/yktrace/src/hwt/mapper.rs
+++ b/yktrace/src/hwt/mapper.rs
@@ -84,7 +84,7 @@ fn get_phdr_offset() -> u64 {
 fn load_labels() -> IntervalTree<usize, SirLabel> {
     let pathb = env::current_exe().unwrap();
     let file = fs::File::open(&pathb.as_path()).unwrap();
-    let mmap = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
     let object = object::File::parse(&*mmap).unwrap();
     let sec = object.section_by_name(ykpack::YKLABELS_SECTION).unwrap();
     let vec = bincode::deserialize::<Vec<SirLabel>>(sec.data().unwrap()).unwrap();

--- a/yktrace/src/sir.rs
+++ b/yktrace/src/sir.rs
@@ -2,7 +2,7 @@
 
 use fallible_iterator::FallibleIterator;
 use fxhash::FxHashMap;
-use memmap::Mmap;
+use memmap2::Mmap;
 use object::{Object, ObjectSection};
 use std::{
     convert::TryFrom,

--- a/yktrace/src/tir.rs
+++ b/yktrace/src/tir.rs
@@ -723,7 +723,7 @@ pub mod tests {
         let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
         let matcher = FMBuilder::new(ptn)
             .unwrap()
-            .name_matcher(Some((ptn_re, text_re)))
+            .name_matcher(ptn_re, text_re)
             .distinct_name_matching(true)
             .build()
             .unwrap();

--- a/ykview/Cargo.toml
+++ b/ykview/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-memmap = "0.7.0"
+memmap2 = "0.2.0"
 ykpack = { path = "../ykpack" }
 yktrace = { path = "../yktrace" }

--- a/ykview/src/main.rs
+++ b/ykview/src/main.rs
@@ -1,4 +1,4 @@
-use memmap::Mmap;
+use memmap2::Mmap;
 use std::{fs::File, io::Read};
 
 fn main() {


### PR DESCRIPTION
This change does three things:
 - Update all dependencies to latest versions, including dynasm to silence a security audit warning about the unmaintained `memmap` crate. Dynasm now uses `memmap2`.
 - Also use `memmap2` in our own code, again to silenced the audit.
 - A minimal fix to silence a deprecation warning that would otherwise block CI.