### PR TITLE
Downgrade serde a minor version.

### DIFF
--- a/ykpack/Cargo.toml
+++ b/ykpack/Cargo.toml
@@ -10,4 +10,4 @@ bincode = "1.3.1"
 bitflags = "1.2.1"
 fallible-iterator = "0.2.0"
 fxhash = "0.2.1"
-serde = { version = "1.0.119", features = ["derive"] }
+serde = { version = "1.0.118", features = ["derive"] }


### PR DESCRIPTION
In the last deps update I broke ykrustc:
```
error: failed to select a version for `serde`.
    ... required by package `ykpack v0.1.0 (https://github.com/softdevteam/yk#6abf57f4)`
    ... which is depended on by `rustc_codegen_llvm v0.0.0 (/home/vext01/research/yorick/ykrustc/compiler/rustc_codegen_llvm)`
    ... which is depended on by `rustc_interface v0.0.0 (/home/vext01/research/yorick/ykrustc/compiler/rustc_interface)`
    ... which is depended on by `rustc_driver v0.0.0 (/home/vext01/research/yorick/ykrustc/compiler/rustc_driver)`
    ... which is depended on by `rustc-main v0.0.0 (/home/vext01/research/yorick/ykrustc/compiler/rustc)`
versions that meet the requirements `^1.0.119` are: 1.0.119

all possible versions conflict with previously selected packages.

  previously selected package `serde v1.0.118`
    ... which is depended on by `bincode v1.3.1`
    ... which is depended on by `rustc_codegen_ssa v0.0.0 (/home/vext01/research/yorick/ykrustc/compiler/rustc_codegen_ssa)`
    ... which is depended on by `rustc-main v0.0.0 (/home/vext01/research/yorick/ykrustc/compiler/rustc)`
```

That's curious because 1.0.118 should be semver compatible with 1.0.119.

If we force the serde version in Cargo.lock we see the problem:
```
error: failed to select a version for `serde_derive`.
    ... required by package `serde v1.0.119`
    ... which is depended on by `bootstrap v0.0.0 (/home/vext01/research/yorick/ykrustc/src/bootstrap)`
versions that meet the requirements `=1.0.119` are: 1.0.119
```

Notice the `=` constraint? I checked that serde-1.0.118 has a similar
constraint, and it does.

In other words, serde minor versions are incompatible.