### PR TITLE
Use MIR liveness analysis instead of our own.

### DIFF
--- a/ykbh/src/lib.rs
+++ b/ykbh/src/lib.rs
@@ -196,10 +196,10 @@ impl SIRInterpreter {
                     Statement::Nop => {}
                     Statement::Unimplemented(_) | Statement::Debug(_) => todo!(),
                     Statement::Cast(..) => todo!(),
-                    Statement::Call(..) | Statement::StorageDead(_) => unreachable!(),
+                    Statement::StorageLive(_) | Statement::StorageDead(_) => {}
+                    Statement::Call(..) => unreachable!(),
                 }
             }
-
             match &block.term {
                 Terminator::Call {
                     operand: op,


### PR DESCRIPTION
We previously ran our own liveness analysis to be able to remove
variables and statements that weren't relevant for the TIR trace.
However, for blackholing we now need to keep the variables and
statements around as they may be needed in the SIR. This means we can go
back to using MIRs liveness analysis to compute live variables for the
guards.