### PR TITLE
Implement blackholing.

### DIFF
--- a/internal_ws/ykbh/src/lib.rs
+++ b/internal_ws/ykbh/src/lib.rs
@@ -1,11 +1,21 @@
 use std::alloc::{alloc, dealloc, Layout};
 use std::convert::TryFrom;
-use std::sync::Arc;
 use ykpack::{
-    self, Body, BodyFlags, CallOperand, Constant, ConstantInt, IPlace, Local, Statement,
-    Terminator, UnsignedInt,
+    self, CallOperand, Constant, ConstantInt, IPlace, Local, Statement, Terminator, TyKind,
+    UnsignedInt, UnsignedIntTy,
 };
 use yktrace::sir::SIR;
+
+/// Stores information needed to recreate stack frames in the SIRInterpreter.
+pub struct FrameInfo {
+    /// The symbol name of this frame.
+    pub sym: String,
+    /// Index of the current basic block we are in. When returning from a function call, the
+    /// terminator of this block is were we continue.
+    pub bbidx: usize,
+    /// Pointer to memory containing the live variables.
+    pub mem: *mut u8,
+}
 
 /// A stack frame for writing and reading locals. Note that the allocated memory this frame points
 /// to needs to be freed manually before the stack frame is destoyed.
@@ -126,23 +136,76 @@ impl StackFrame {
     }
 }
 
+/// The SIR interpreter, also known as blackholing interpreter, is invoked when a guard fails in a
+/// trace. It is initalised with information from the trace, e.g. live variables, stack frames, and
+/// then run to get us back to a control point from where the normal interpreter then takes over.
 pub struct SIRInterpreter {
+    /// Keeps track of the current stack frames, created by function calls.
     frames: Vec<StackFrame>,
+    /// Index of the basic block we were in when a function was called. Upon returning from a
+    /// function, we go back to this basic block and look up its terminator to decide where to
+    /// continue.
+    returns: Vec<ykpack::BasicBlockIndex>,
+    /// Function names relating to each stack frame. These are needed to retrieve the SIR body of
+    /// the function which contains the statements we want to interpret.
+    funcs: Vec<String>,
+    /// Index of the basic block we are currently interpreting.
     bbidx: ykpack::BasicBlockIndex,
 }
 
 impl SIRInterpreter {
-    pub fn new(body: &Body) -> Self {
-        let frame = SIRInterpreter::create_frame(body);
+    pub fn new(sym: String) -> Self {
+        let frame = SIRInterpreter::create_frame(&sym);
         SIRInterpreter {
             frames: vec![frame],
+            returns: Vec::new(),
+            funcs: vec![sym],
             bbidx: 0,
         }
     }
 
+    /// Initialises the interpreter with information about live variables and stack frames,
+    /// received from the failing guard.
+    pub fn init_frames(v: Vec<FrameInfo>) -> Self {
+        let mut frames = Vec::new();
+        let mut funcs = Vec::new();
+        let mut returns = Vec::new();
+        for fi in v {
+            let body = SIR.body(&fi.sym).unwrap();
+            let frame = StackFrame {
+                locals: fi.mem,
+                offsets: body.offsets.clone(),
+                layout: Layout::from_size_align(body.layout.0, body.layout.1).unwrap(),
+            };
+            frames.push(frame);
+            funcs.push(fi.sym);
+            returns.push(u32::try_from(fi.bbidx).unwrap());
+        }
+        SIRInterpreter {
+            frames,
+            returns,
+            funcs,
+            bbidx: 0,
+        }
+    }
+
+    /// Run the SIR interpreter after it has been initialised by a guard failure. Since we start in
+    /// the block where the guard failed, we immediately skip to the terminator and interpret it to
+    /// see which block we need to start interpretation in.
+    pub unsafe fn interpret(&mut self) {
+        // Jump to the correct basic block.
+        let lastfunc = self.funcs.last().unwrap();
+        let lastret = *self.returns.last().unwrap();
+        let body = SIR.body(lastfunc).unwrap();
+        self.terminator(&body.blocks[lastret as usize].term);
+        // Start interpretation.
+        self._interpret();
+    }
+
     /// Given a vector of local declarations, create a new StackFrame, which allocates just enough
     /// space to hold all of them.
-    fn create_frame(body: &Body) -> StackFrame {
+    fn create_frame(sym: &String) -> StackFrame {
+        let body = SIR.body(&sym).unwrap();
         let (size, align) = body.layout;
         let offsets = body.offsets.clone();
         let layout = Layout::from_size_align(size, align).unwrap();
@@ -176,22 +239,16 @@ impl SIRInterpreter {
         }
     }
 
-    pub unsafe fn interpret(&mut self, body: Arc<ykpack::Body>) {
-        // Ignore yktrace::trace_debug.
-        if body.flags.contains(BodyFlags::TRACE_DEBUG) {
-            return;
-        }
-
-        let mut bodies = vec![body];
-        let mut returns = Vec::new();
-        while let Some(body) = bodies.last() {
+    pub unsafe fn _interpret(&mut self) {
+        while let Some(func) = self.funcs.last() {
+            let body = SIR.body(&func).unwrap();
             let bbidx = usize::try_from(self.bbidx).unwrap();
             let block = &body.blocks[bbidx];
             for stmt in block.stmts.iter() {
                 match stmt {
-                    Statement::MkRef(dest, src) => self.mkref(dest, src),
+                    Statement::MkRef(dest, src) => self.mkref(&dest, &src),
                     Statement::DynOffs { .. } => todo!(),
-                    Statement::Store(dest, src) => self.store(dest, src),
+                    Statement::Store(dest, src) => self.store(&dest, &src),
                     Statement::BinaryOp { .. } => todo!(),
                     Statement::Nop => {}
                     Statement::Unimplemented(_) | Statement::Debug(_) => todo!(),
@@ -200,51 +257,98 @@ impl SIRInterpreter {
                     Statement::Call(..) => unreachable!(),
                 }
             }
-            match &block.term {
-                Terminator::Call {
-                    operand: op,
-                    args,
-                    destination: dest,
-                } => {
-                    let fname = if let CallOperand::Fn(sym) = op {
-                        sym
-                    } else {
-                        todo!("unknown call target");
+
+            self.terminator(&block.term);
+        }
+    }
+
+    fn terminator(&mut self, term: &Terminator) {
+        match term {
+            Terminator::Call {
+                operand: op,
+                args,
+                destination: _dest,
+            } => {
+                let fname = if let CallOperand::Fn(sym) = op {
+                    sym
+                } else {
+                    todo!("unknown call target");
+                };
+
+                // Initialise the new stack frame.
+                let mut frame = SIRInterpreter::create_frame(&fname);
+                frame.copy_args(args, self.frame());
+                self.frames.push(frame);
+                self.returns.push(self.bbidx);
+                self.funcs.push(fname.to_string());
+                self.bbidx = 0;
+            }
+            Terminator::Return => {
+                self.funcs.pop();
+                // Are we still inside a nested call? Otherwise we are returning from the first
+                // body, so we are done interpreting.
+                if self.funcs.len() > 0 {
+                    let returnbb = self.returns.pop().unwrap();
+                    let func = self.funcs.last().unwrap();
+                    let body = SIR.body(&func).unwrap();
+                    // Check the previous call terminator to find out where we have to go next.
+                    let (dest, bbidx) = match &body.blocks[usize::try_from(returnbb).unwrap()].term
+                    {
+                        Terminator::Call {
+                            operand: _,
+                            args: _,
+                            destination: dest,
+                        } => dest.as_ref().map(|(p, b)| (p.clone(), *b)).unwrap(),
+                        _ => unreachable!(),
                     };
 
-                    // Initialise the new stack frame.
-                    let body = SIR.body(fname).unwrap();
-                    let mut frame = SIRInterpreter::create_frame(&*body);
-                    frame.copy_args(args, self.frame());
-                    self.frames.push(frame);
-                    self.bbidx = 0;
-                    returns.push(dest.as_ref().map(|(p, b)| (p.clone(), *b)));
-                    bodies.push(body);
+                    // Restore the previous stack frame, but keep the other frame around so we
+                    // can copy over the return value to the destination.
+                    let oldframe = self.frames.pop().unwrap();
+                    // Get a pointer to the return value of the called frame.
+                    let ret_ptr = oldframe.local_ptr(&Local(0));
+                    // Write the return value to the destination in the previous frame.
+                    let dst_ptr = self.frame().iplace_to_ptr(&dest);
+                    let size = usize::try_from(SIR.ty(&dest.ty()).size()).unwrap();
+                    self.frame_mut().write_val(dst_ptr, ret_ptr, size);
+                    self.bbidx = bbidx;
                 }
-                Terminator::Return => {
-                    // Are we returning from a call?
-                    if let Some(v) = returns.pop() {
-                        // Restore the previous stack frame, but keep the other frame around so we
-                        // can copy over the return value to the destination.
-                        let oldframe = self.frames.pop().unwrap();
-                        if let Some((dest, bbidx)) = v {
-                            // Get a pointer to the return value of the called frame.
-                            let ret_ptr = oldframe.local_ptr(&Local(0));
-                            // Write the return value to the destination in the previous frame.
-                            let dst_ptr = self.frame().iplace_to_ptr(&dest);
-                            let size = usize::try_from(SIR.ty(&dest.ty()).size()).unwrap();
-                            self.frame_mut().write_val(dst_ptr, ret_ptr, size);
-                            self.bbidx = bbidx;
-                        }
-                        // Restore previous body.
-                        bodies.pop();
-                    } else {
-                        // We are returning from the first body, so we are done interpreting.
+            }
+            Terminator::SwitchInt {
+                discr,
+                values,
+                target_bbs,
+                otherwise_bb,
+            } => {
+                let val = self.read_int(discr);
+                self.bbidx = *otherwise_bb;
+                for (i, v) in values.iter().enumerate() {
+                    if val == *v {
+                        self.bbidx = target_bbs[i];
                         break;
                     }
                 }
-                t => todo!("{}", t),
             }
+            Terminator::Goto(bb) => {
+                self.bbidx = *bb;
+            }
+            t => todo!("{}", t),
+        }
+    }
+
+    fn read_int(&self, src: &IPlace) -> u128 {
+        let ptr = self.frame().iplace_to_ptr(src);
+        match &SIR.ty(&src.ty()).kind {
+            TyKind::UnsignedInt(ui) => match ui {
+                UnsignedIntTy::Usize => todo!(),
+                UnsignedIntTy::U8 => unsafe { u128::from(std::ptr::read::<u8>(ptr)) },
+                UnsignedIntTy::U16 => todo!(),
+                UnsignedIntTy::U32 => todo!(),
+                UnsignedIntTy::U64 => todo!(),
+                UnsignedIntTy::U128 => todo!(),
+            },
+            TyKind::SignedInt(_si) => unreachable!(),
+            _ => unreachable!(),
         }
     }
 

--- a/internal_ws/ykbh/src/lib.rs
+++ b/internal_ws/ykbh/src/lib.rs
@@ -48,11 +48,15 @@ impl StackFrame {
             Constant::Int(ci) => match ci {
                 ConstantInt::UnsignedInt(ui) => match ui {
                     UnsignedInt::U8(v) => self.write_val(dest, [*v].as_ptr(), 1),
+                    UnsignedInt::Usize(v) => {
+                        let bytes = v.to_ne_bytes();
+                        self.write_val(dest, bytes.as_ptr(), bytes.len())
+                    }
                     _ => todo!(),
                 },
                 ConstantInt::SignedInt(_si) => todo!(),
             },
-            Constant::Bool(_b) => todo!(),
+            Constant::Bool(b) => self.write_val(dest, [*b as u8].as_ptr(), 1),
             Constant::Tuple(t) => {
                 if SIR.ty(t).size() == 0 {
                     // ZST: do nothing.
@@ -349,6 +353,7 @@ impl SIRInterpreter {
                 UnsignedIntTy::U128 => todo!(),
             },
             TyKind::SignedInt(_si) => unreachable!(),
+            TyKind::Bool => unsafe { u128::from(std::ptr::read::<u8>(ptr)) },
             _ => unreachable!(),
         }
     }

--- a/internal_ws/ykcompile/Cargo.toml
+++ b/internal_ws/ykcompile/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1.4.0"
 libc = "0.2.82"
 ykpack = { path = "../ykpack" }
 yktrace = { path = "../yktrace" }
+ykbh = { path = "../ykbh" }
 
 [dev-dependencies]
 fm = "0.2.0"

--- a/internal_ws/ykshim/src/prod_api.rs
+++ b/internal_ws/ykshim/src/prod_api.rs
@@ -106,3 +106,15 @@ unsafe extern "C" fn __ykshim_sirtrace_drop(trace: *mut SirTrace) {
 unsafe fn __ykshim_tirtrace_drop(tir_trace: *mut TirTrace) {
     Box::from_raw(tir_trace);
 }
+
+/// Start an initialised SIRInterpreter.
+#[no_mangle]
+unsafe extern "C" fn __ykshim_si_interpret(si: *mut ykbh::SIRInterpreter, icx: *mut u8) {
+    let si = &mut *si;
+    si.interpret(icx);
+}
+
+#[no_mangle]
+unsafe extern "C" fn __ykshim_sirinterpreter_drop(interp: *mut ykbh::SIRInterpreter) {
+    Box::from_raw(interp);
+}

--- a/internal_ws/ykshim/src/test_api.rs
+++ b/internal_ws/ykshim/src/test_api.rs
@@ -112,12 +112,10 @@ unsafe extern "C" fn __ykshimtest_tracecompiler_find_sym(sym: *mut c_char) -> *m
 /// Interpret a SIR body with the specified interpreter context.
 #[no_mangle]
 unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *mut c_char, icx: *mut u8) {
-    let body = SIR
-        .body(CString::from_raw(body_name).to_str().unwrap())
-        .unwrap();
-    let mut si = SIRInterpreter::new(&*body);
+    let fname = CString::from_raw(body_name).to_str().unwrap().to_string();
+    let mut si = SIRInterpreter::new(fname);
     si.set_trace_inputs(icx);
-    si.interpret(body);
+    si._interpret();
 }
 
 /// Returns the size of the register allocators register pool.

--- a/internal_ws/yktrace/src/tir.rs
+++ b/internal_ws/yktrace/src/tir.rs
@@ -104,6 +104,11 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                         symbol_name: loc.symbol_name,
                         bb_idx: loc.bb_idx
                     });
+                } else {
+                    // Update the basic block index of the current guard block, so the guard
+                    // failure can later jump to the correct block when initialising the SIR
+                    // interpreter.
+                    guard_blocks.last_mut().unwrap().bb_idx = loc.bb_idx;
                 }
 
                 // When converting the SIR trace into a TIR trace we alpha-rename the `Local`s from

--- a/internal_ws/yktrace/src/tir.rs
+++ b/internal_ws/yktrace/src/tir.rs
@@ -46,7 +46,8 @@ impl<'a, 'm> TirTrace<'a, 'm> {
         // popping from the stack).
         let mut return_iplaces: Vec<IPlace> = Vec::new();
 
-        let mut live_locals: HashSet<Local> = HashSet::new();
+        let mut live_locals: Vec<HashSet<Local>> = Vec::new();
+        let mut guard_blocks: Vec<GuardBlock> = Vec::new();
 
         let mut in_interp_step = false;
         while let Some(loc) = itr.next() {
@@ -92,6 +93,19 @@ impl<'a, 'm> TirTrace<'a, 'm> {
 
             // If we are not in the `interp_step` function, then ignore statements.
             if in_interp_step {
+                // For each new function we enter during the trace, create a new guard block. The
+                // list of guard blocks is later added to the guard, enabling us to recreate the
+                // stack frames for blackholing.
+                if guard_blocks.len() == 0
+                    || guard_blocks.last().unwrap().symbol_name != loc.symbol_name
+                {
+                    live_locals.push(HashSet::new());
+                    guard_blocks.push(GuardBlock {
+                        symbol_name: loc.symbol_name,
+                        bb_idx: loc.bb_idx
+                    });
+                }
+
                 // When converting the SIR trace into a TIR trace we alpha-rename the `Local`s from
                 // inlined functions by adding an offset to each. This offset is derived from the
                 // number of assigned variables in the functions outer context. For example, if a
@@ -139,12 +153,12 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                         ),
                         Statement::StorageLive(local) => {
                             let l = rnm.rename_local(local, &body);
-                            live_locals.insert(l);
+                            live_locals.last_mut().unwrap().insert(l);
                             Statement::StorageLive(l)
                         }
                         Statement::StorageDead(local) => {
                             let l = rnm.rename_local(local, &body);
-                            live_locals.remove(&l);
+                            live_locals.last_mut().unwrap().remove(&l);
                             Statement::StorageDead(l)
                         }
                         // The following statements are specific to TIR and cannot appear in SIR.
@@ -182,6 +196,8 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                             if in_interp_step {
                                 panic!("recursion into interp_step detected");
                             }
+                            // FIXME This means we add this call terminator to the statements, even
+                            // though the rest of this block was skipped.
                             in_interp_step = true;
                             continue;
                         }
@@ -313,10 +329,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                         Some(idx) => Some(Guard {
                             val: rnm.rename_iplace(discr, &body),
                             kind: GuardKind::Integer(values[idx]),
-                            block: GuardBlock {
-                                symbol_name: loc.symbol_name,
-                                bb_idx: loc.bb_idx
-                            },
+                            block: Vec::new(),
                             live_locals: Vec::new()
                         }),
                         None => {
@@ -324,10 +337,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                             Some(Guard {
                                 val: rnm.rename_iplace(discr, &body),
                                 kind: GuardKind::OtherInteger(values.iter().cloned().collect()),
-                                block: GuardBlock {
-                                    symbol_name: loc.symbol_name,
-                                    bb_idx: loc.bb_idx
-                                },
+                                block: Vec::new(),
                                 live_locals: Vec::new()
                             })
                         }
@@ -340,10 +350,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                 } => Some(Guard {
                     val: rnm.rename_iplace(cond, &body),
                     kind: GuardKind::Boolean(*expected),
-                    block: GuardBlock {
-                        symbol_name: loc.symbol_name,
-                        bb_idx: loc.bb_idx
-                    },
+                    block: Vec::new(),
                     live_locals: Vec::new()
                 }),
                 Terminator::TraceDebugCall { ref msg, .. } => {
@@ -354,12 +361,19 @@ impl<'a, 'm> TirTrace<'a, 'm> {
             };
 
             if let Some(mut g) = guard {
-                for local in &live_locals {
-                    let sirlocal = rnm.sir_map.get(local).unwrap();
-                    g.live_locals.push(LiveLocal {
-                        tir: *local,
-                        sir: *sirlocal
-                    });
+                for gb in &guard_blocks {
+                    g.block.push(gb.clone());
+                }
+                for ll in &live_locals {
+                    let mut v = Vec::new();
+                    for local in ll {
+                        let sirlocal = rnm.sir_map.get(local).unwrap();
+                        v.push(LiveLocal {
+                            tir: *local,
+                            sir: *sirlocal
+                        });
+                    }
+                    g.live_locals.push(v);
                 }
                 let op = TirOp::Guard(g);
                 ops.push(op);
@@ -507,7 +521,7 @@ impl Display for TirTrace<'_, '_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GuardBlock {
     pub symbol_name: &'static str,
     pub bb_idx: ykpack::BasicBlockIndex
@@ -522,8 +536,8 @@ impl Display for GuardBlock {
 /// A mapping from a TIR local to its equivalent in SIR.
 #[derive(Debug)]
 pub struct LiveLocal {
-    tir: Local,
-    sir: Local
+    pub tir: Local,
+    pub sir: Local
 }
 
 /// A guard states the assumptions from its position in a trace onward.
@@ -535,27 +549,28 @@ pub struct Guard {
     pub kind: GuardKind,
     /// The block whose terminator was the basis for this guard. This is here so that, in the event
     /// that the guard fails, we know where to start the blackhole interpreter.
-    pub block: GuardBlock,
+    pub block: Vec<GuardBlock>,
     /// The TIR locals (and their SIR equivalent) that are live at the time of the guard. This is
     /// needed so that we can initialise the blackhole interpreter with the correct state.
-    pub live_locals: Vec<LiveLocal>
+    pub live_locals: Vec<Vec<LiveLocal>>
 }
 
 impl fmt::Display for Guard {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut live = String::from("");
-        write!(
-            live,
-            "{}",
-            self.live_locals
-                .iter()
-                .map(|ll| ll.tir.to_string())
-                .collect::<Vec<String>>()
-                .join(", ")
-        )?;
+        for ll in &self.live_locals {
+            write!(
+                live,
+                "[{}]",
+                ll.iter()
+                    .map(|l| l.tir.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )?;
+        }
         write!(
             f,
-            "guard({}, {}, {}, [{}])",
+            "guard({}, {}, {:?}, [{}])",
             self.val, self.kind, self.block, live
         )
     }

--- a/tests/src/guardfailure.rs
+++ b/tests/src/guardfailure.rs
@@ -77,3 +77,41 @@ fn recursion() {
     unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
     assert_eq!(args.1, 99);
 }
+
+#[ignore]
+#[test]
+fn recursion2() {
+    struct IO(u8, u8);
+
+    // Test that the SIR interpreter can deal with new recursions after a guard failure.
+    fn rec(i: u8, j: u8) -> u8 {
+        if i < 5 {
+            return rec(i + 1, j + 1);
+        } else {
+            return j;
+        }
+    }
+
+    #[interp_step]
+    fn interp_step(io: &mut IO) {
+        let x = rec(io.0, io.1);
+        io.1 = x;
+    }
+
+    let mut inputs = IO(7, 0);
+    let th = start_tracing(TracingKind::HardwareTracing);
+    interp_step(&mut inputs);
+    let sir_trace = th.stop_tracing().unwrap();
+    let ct = compile_trace(sir_trace).unwrap();
+    let mut args = IO(7, 1);
+    assert!(unsafe { ct.execute(&mut args).is_null() });
+    assert_eq!(args.1, 1);
+    // Execute trace with input that fails the guard.
+    let mut args = IO(1, 0);
+    let ptr = unsafe { ct.execute(&mut args) };
+    assert!(!ptr.is_null());
+    // Check that running the interpreter gets us the correct result.
+    let mut si: SIRInterpreter = SIRInterpreter(ptr);
+    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    assert_eq!(args.1, 5);
+}

--- a/tests/src/guardfailure.rs
+++ b/tests/src/guardfailure.rs
@@ -1,0 +1,79 @@
+use ykshim_client::{compile_trace, start_tracing, SIRInterpreter, TracingKind};
+
+#[test]
+fn simple() {
+    struct IO(u8, u8);
+
+    fn guard(i: u8) -> u8 {
+        if i != 3 {
+            9
+        } else {
+            10
+        }
+    }
+
+    #[interp_step]
+    fn interp_step(io: &mut IO) {
+        let x = guard(io.0);
+        io.1 = x;
+    }
+
+    let mut inputs = IO(std::hint::black_box(|i| i)(0), 0);
+    let th = start_tracing(TracingKind::HardwareTracing);
+    interp_step(&mut inputs);
+    let sir_trace = th.stop_tracing().unwrap();
+    let ct = compile_trace(sir_trace).unwrap();
+    let mut args = IO(0, 0);
+    assert!(unsafe { ct.execute(&mut args).is_null() });
+    assert_eq!(args.1, 9);
+    // Execute trace with input that fails the guard.
+    let mut args = IO(3, 0);
+    let ptr = unsafe { ct.execute(&mut args) };
+    assert!(!ptr.is_null());
+    // Check that running the interpreter gets us the correct result.
+    let mut si: SIRInterpreter = SIRInterpreter(ptr);
+    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    assert_eq!(args.1, 10);
+}
+
+#[test]
+fn recursion() {
+    struct IO(u8, u8);
+
+    // Test that if a guard fails within a recursive call, we still construct the correct stack
+    // frames for the blackholing interpreter.
+    fn rec(i: u8, j: u8) -> u8 {
+        let mut k = i;
+        if i < 1 {
+            k = rec(i + 1, j);
+            if j == 1 {
+                // Produce a guard failure here deep within multiple recursions.
+                k = 99;
+            }
+        }
+        return k;
+    }
+
+    #[interp_step]
+    fn interp_step(io: &mut IO) {
+        let x = rec(io.0, io.1);
+        io.1 = x;
+    }
+
+    let mut inputs = IO(std::hint::black_box(|i| i)(0), 0);
+    let th = start_tracing(TracingKind::HardwareTracing);
+    interp_step(&mut inputs);
+    let sir_trace = th.stop_tracing().unwrap();
+    let ct = compile_trace(sir_trace).unwrap();
+    let mut args = IO(0, 0);
+    assert!(unsafe { ct.execute(&mut args).is_null() });
+    assert_eq!(args.1, 1);
+    // Execute trace with input that fails the guard.
+    let mut args = IO(0, 1);
+    let ptr = unsafe { ct.execute(&mut args) };
+    assert!(!ptr.is_null());
+    // Check that running the interpreter gets us the correct result.
+    let mut si: SIRInterpreter = SIRInterpreter(ptr);
+    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    assert_eq!(args.1, 99);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,3 +11,6 @@ mod ykcompile;
 
 #[cfg(test)]
 mod yktrace;
+
+#[cfg(test)]
+mod guardfailure;

--- a/tests/src/ykcompile.rs
+++ b/tests/src/ykcompile.rs
@@ -4,7 +4,7 @@ use libc::{abs, c_void, getuid};
 use std::{collections::HashMap, convert::TryFrom, ptr};
 use ykshim_client::{
     compile_tir_trace, compile_trace, reg_pool_size, sir_body_ret_ty, start_tracing, Local,
-    LocalDecl, LocalIndex, SIRInterpreter, TirTrace, TraceCompiler, TracingKind, TypeId,
+    LocalDecl, LocalIndex, TirTrace, TraceCompiler, TracingKind, TypeId,
 };
 
 extern "C" {
@@ -1066,10 +1066,6 @@ fn guard() {
     let mut args = IO(3, 0);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());
-    // Check that running the interpreter gets us the correct result.
-    let mut si: SIRInterpreter = SIRInterpreter(ptr);
-    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
-    assert_eq!(args.1, 10);
 }
 
 #[test]

--- a/tests/src/ykcompile.rs
+++ b/tests/src/ykcompile.rs
@@ -4,7 +4,7 @@ use libc::{abs, c_void, getuid};
 use std::{collections::HashMap, convert::TryFrom, ptr};
 use ykshim_client::{
     compile_tir_trace, compile_trace, reg_pool_size, sir_body_ret_ty, start_tracing, Local,
-    LocalDecl, LocalIndex, TirTrace, TraceCompiler, TracingKind, TypeId,
+    LocalDecl, LocalIndex, SIRInterpreter, TirTrace, TraceCompiler, TracingKind, TypeId,
 };
 
 extern "C" {
@@ -82,7 +82,7 @@ fn simple() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 13);
 }
 
@@ -278,7 +278,7 @@ fn function_call_simple() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 13);
 }
 
@@ -306,7 +306,7 @@ fn function_call_nested() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 20);
 }
 
@@ -372,7 +372,7 @@ fn exec_call_symbol_no_args() {
     let sir_trace = th.stop_tracing().unwrap();
     let mut args = IO(0);
     let ct = compile_trace(sir_trace).unwrap();
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(inputs.0, args.0);
 }
 
@@ -391,7 +391,7 @@ fn exec_call_symbol_with_arg() {
     let sir_trace = th.stop_tracing().unwrap();
     let mut args = IO(-56);
     let ct = compile_trace(sir_trace).unwrap();
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(inputs.0, args.0);
 }
 
@@ -410,7 +410,7 @@ fn exec_call_symbol_with_const_arg() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(inputs.0, args.0);
 }
 
@@ -428,7 +428,7 @@ fn exec_call_symbol_with_many_args() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(inputs.0, 21);
     assert_eq!(inputs.0, args.0);
 }
@@ -447,7 +447,7 @@ fn exec_call_symbol_with_many_args_some_ignored() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 7);
     assert_eq!(args.0, inputs.0);
 }
@@ -475,7 +475,7 @@ fn ext_call_and_spilling() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(inputs.0, 7);
     assert_eq!(inputs.0, args.0);
 }
@@ -496,7 +496,7 @@ fn binop_add_simple() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(5, 2, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args, IO(5, 2, 10));
 }
 
@@ -519,12 +519,12 @@ fn binop_add_overflow() {
 
     // Executing a trace with no overflow shouldn't fail any guards.
     let mut args = IO(10, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args, IO(10, 11));
 
     // Executing a trace *with* overflow will fail a guard.
     let mut args = IO(255, 5);
-    assert!(!unsafe { ct.execute(&mut args) });
+    assert!(!unsafe { ct.execute(&mut args).is_null() });
 }
 
 #[test]
@@ -544,7 +544,7 @@ fn binop_other() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(5, 2, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args, IO(5, 5, 10));
 }
 
@@ -567,7 +567,7 @@ fn ref_deref_simple() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 10);
 }
 
@@ -590,7 +590,7 @@ fn ref_deref_double() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 4);
 }
 
@@ -613,7 +613,7 @@ fn ref_deref_double_and_field() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 5);
 }
 
@@ -642,7 +642,7 @@ fn ref_deref_stack() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 10);
 }
 
@@ -670,7 +670,7 @@ fn deref_stack_to_register() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 6);
 }
 
@@ -699,7 +699,7 @@ fn deref_register_to_stack() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args) }.is_null());
     assert_eq!(args.0, 6);
 }
 
@@ -738,7 +738,7 @@ fn do_not_trace() {
 
     let ct = compile_tir_trace(tir_trace).unwrap();
     let mut args = IO(1);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 3);
 }
 
@@ -759,7 +759,7 @@ fn do_not_trace_stdlib() {
     let ct = compile_trace(sir_trace).unwrap();
     let mut argv: Vec<u64> = Vec::new();
     let mut args = IO(&mut argv);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(argv.len(), 1);
     assert_eq!(argv[0], 3);
 }
@@ -792,7 +792,7 @@ fn projection_chain() {
     let t2 = (1, 2, 3);
     let s2 = S { x: 5, y: 6 };
     let mut args = IO(t2, 0u8, s2, 0usize);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, (1usize, 2u8, 3usize));
     assert_eq!(args.1, 2u8);
     assert_eq!(args.2, S { x: 5, y: 6 });
@@ -816,7 +816,7 @@ fn projection_lhs() {
     let ct = compile_trace(sir_trace).unwrap();
     let t2 = (1u8, 2u8);
     let mut args = IO(t2, 3u8);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!((args.0).1, 3);
 }
 
@@ -840,7 +840,7 @@ fn array() {
     let ct = compile_trace(sir_trace).unwrap();
     let mut a2 = [3, 4, 5];
     let mut args = IO(&mut a2, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 4);
 }
 
@@ -864,7 +864,7 @@ fn array_nested() {
     let ct = compile_trace(sir_trace).unwrap();
     let mut a2 = [[3, 4, 5], [6, 7, 8]];
     let mut args = IO(&mut a2, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 8);
 }
 
@@ -889,7 +889,7 @@ fn array_nested_mad() {
     let ct = compile_trace(sir_trace).unwrap();
     let mut a2 = [S([3, 4, 5, 6]), S([7, 8, 9, 10]), S([11, 12, 13, 14])];
     let mut args = IO(&mut a2, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 13);
 }
 
@@ -910,7 +910,7 @@ fn rhs_struct_ref_field() {
     let ct = compile_trace(sir_trace).unwrap();
 
     let mut args = IO(10);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 11);
 }
 
@@ -931,7 +931,7 @@ fn mut_lhs_struct_ref() {
     let ct = compile_trace(sir_trace).unwrap();
 
     let mut args = IO(10);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 100);
 }
 
@@ -955,7 +955,7 @@ fn place_larger_than_reg() {
     assert_eq!(inputs.0, S(10, 10, 10));
 
     let mut args = IO(S(1, 1, 1));
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, S(10, 10, 10));
 }
 
@@ -976,7 +976,7 @@ fn array_slice_index() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(&a, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 3);
 }
 
@@ -1001,7 +1001,7 @@ fn trim_junk() {
     let ct = compile_trace(sir_trace).unwrap();
 
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 3);
 }
 
@@ -1032,7 +1032,7 @@ fn comparison() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0, false);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, true);
 }
 
@@ -1060,11 +1060,16 @@ fn guard() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0, 0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 9);
     // Execute trace with input that fails the guard.
     let mut args = IO(3, 0);
-    assert!(!unsafe { ct.execute(&mut args) });
+    let ptr = unsafe { ct.execute(&mut args) };
+    assert!(!ptr.is_null());
+    // Check that running the interpreter gets us the correct result.
+    let mut si: SIRInterpreter = SIRInterpreter(ptr);
+    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    assert_eq!(args.1, 10);
 }
 
 #[test]
@@ -1087,7 +1092,7 @@ fn matching() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(1);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 2);
 }
 
@@ -1113,7 +1118,7 @@ fn cast() {
     assert_eq!(io.0, 1);
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0, 97);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 1);
 }
 
@@ -1138,9 +1143,9 @@ fn vec_add() {
     let ct = compile_trace(sir_trace).unwrap();
     let cells = vec![1, 2, 3];
     let mut args = IO { ptr: 1, cells };
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.cells, vec![1, 3, 3]);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.cells, vec![1, 4, 3]);
 }
 
@@ -1171,6 +1176,6 @@ fn nested_do_not_trace() {
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0);
-    assert!(unsafe { ct.execute(&mut args) });
+    assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.0, 1);
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -17,7 +17,10 @@ use crate::location::{
     CompilingTrace, Location, State, PHASE_COMPILED, PHASE_COMPILING, PHASE_COUNTING,
     PHASE_DONT_TRACE, PHASE_LOCKED, PHASE_TRACING, PHASE_TRACING_LOCK,
 };
-use ykshim_client::{compile_trace, start_tracing, CompiledTrace, ThreadTracer, TracingKind};
+use ykshim_client::{
+    compile_trace, start_tracing, CompiledTrace, RawSIRInterpreter, SIRInterpreter, ThreadTracer,
+    TracingKind,
+};
 
 pub type HotThreshold = usize;
 const DEFAULT_HOT_THRESHOLD: HotThreshold = 50;
@@ -184,7 +187,8 @@ impl MTThread {
         // this thread's tracer.
         if let Some(loc) = loc {
             if let Some(func) = self.transition_location::<I>(loc) {
-                if self.exec_trace(func, inputs) {
+                let ptr = self.exec_trace(func, inputs);
+                if ptr.is_null() {
                     // Trace succesfully executed.
                     return;
                 } else {
@@ -196,7 +200,11 @@ impl MTThread {
         step_fn(inputs)
     }
 
-    fn exec_trace<I>(&mut self, func: fn(&mut I) -> bool, inputs: &mut I) -> bool {
+    fn exec_trace<I>(
+        &mut self,
+        func: fn(&mut I) -> *mut RawSIRInterpreter,
+        inputs: &mut I,
+    ) -> *mut RawSIRInterpreter {
         func(inputs)
     }
 
@@ -206,7 +214,7 @@ impl MTThread {
     fn transition_location<I: Send + 'static>(
         &mut self,
         loc: &Location<I>,
-    ) -> Option<fn(&mut I) -> bool> {
+    ) -> Option<fn(&mut I) -> *mut RawSIRInterpreter> {
         // Since we don't hold an explicit lock, updating a Location is tricky: we might read a
         // Location, work out what we'd like to update it to, and try updating it, only to find
         // that another thread interrupted us part way through. We therefore use compare_and_swap
@@ -387,7 +395,9 @@ impl MTThread {
                 match mtx.try_lock() {
                     Ok(mut gd) => {
                         if let Some(tr) = (*gd).take() {
-                            let f = unsafe { mem::transmute::<_, fn(&mut I) -> bool>(tr.ptr()) };
+                            let f = unsafe {
+                                mem::transmute::<_, fn(&mut I) -> *mut RawSIRInterpreter>(tr.ptr())
+                            };
                             loc.store(State::phase_compiled(tr), Ordering::Release);
                             return Some(f);
                         }
@@ -406,7 +416,8 @@ impl MTThread {
             PHASE_LOCKED | PHASE_DONT_TRACE => return None,
             PHASE_COMPILED => {
                 let bct = unsafe { lp.ref_data::<CompiledTrace<I>>() };
-                let f = unsafe { mem::transmute::<_, fn(&mut I) -> bool>(bct.ptr()) };
+                let f =
+                    unsafe { mem::transmute::<_, fn(&mut I) -> *mut RawSIRInterpreter>(bct.ptr()) };
                 return Some(f);
             }
             _ => unreachable!(),


### PR DESCRIPTION
This PR implements "blackholing", i.e. getting from a guard failure in a compiled trace back to the normal interpreter. This is done using a special interpreter, the SIRInterpreter, which runs on SIR blocks. When a guard fails, we check which block in the SIR execution needs to continue. We then initialise the SIRInterpreter at that point, copying over all live values computed during execution of the compiled trace, and then interpret SIR blocks until we get back to the control point (which happens when we return from the `interp_step`-annotated function). For this each guard stores information about which variables are live up to that point. Guards also need to store information about function calls (even though in the compiled trace those are inlined), so that we can recreate the needed stack frames in the SIRInterpreter.

Let me apologise in advance for this PR. I tried splitting things up into multiple commits, but this wasn't possible for the main change (getting the guards to produce the necessary information for blackholing). This the first commit is a lot to take in. The heart of this PR is in the `ret` function (https://github.com/softdevteam/yk/pull/218/commits/956d84e560ed3907812460d2f0db4008e8321398#diff-a0588be717e433bc24ac399f2b57b188c7b13b56c5a512d4c1404d9fac87bf04R1339), which for each guard generates code that allocates memory for the stack frames and fills it with the live variables, and finally instantiates a `SIRInterpreter`. So I suggest you start with that.

If anything isn't clear, please feel free to leave comments asking for clarification and I'll add and commit more comments.

The second commit needs squashing into the first, too, but I've left them apart for now to make reviewing easier.