### PR TITLE
Remove duplication in test

### DIFF
--- a/internal_ws/ykshim/src/prod_api.rs
+++ b/internal_ws/ykshim/src/prod_api.rs
@@ -100,3 +100,9 @@ unsafe extern "C" fn __ykshim_compiled_trace_drop(compiled_trace: *mut CompiledT
 unsafe extern "C" fn __ykshim_sirtrace_drop(trace: *mut SirTrace) {
     Box::from_raw(trace);
 }
+
+/// Drop a TIR trace.
+#[no_mangle]
+unsafe fn __ykshim_tirtrace_drop(tir_trace: *mut TirTrace) {
+    Box::from_raw(tir_trace);
+}

--- a/internal_ws/ykshim/src/test_api.rs
+++ b/internal_ws/ykshim/src/test_api.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_char;
 use std::ptr;
 
 use ykbh::SIRInterpreter;
-use ykcompile::{TraceCompiler, REG_POOL};
+use ykcompile::{CompiledTrace, TraceCompiler, REG_POOL};
 use ykpack::{self, CguHash, Local, LocalDecl, TyIndex};
 use yktrace::sir::{self, SirTrace, SIR};
 use yktrace::tir::TirTrace;
@@ -130,4 +130,13 @@ unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *mut c_char, icx: *m
 #[no_mangle]
 unsafe extern "C" fn __ykshimtest_reg_pool_size() -> usize {
     REG_POOL.len()
+}
+
+/// Consumes and compiles the given TIR trace to native code, returning an opaque pointer to the
+/// compiled trace.
+#[no_mangle]
+fn __ykshimtest_compile_tir_trace(tir_trace: *mut TirTrace) -> *mut CompiledTrace {
+    let tir_trace = unsafe { Box::from_raw(tir_trace) };
+    let compiled_trace = ykcompile::compile_trace(*tir_trace);
+    Box::into_raw(Box::new(compiled_trace))
 }

--- a/internal_ws/ykshim/src/test_api.rs
+++ b/internal_ws/ykshim/src/test_api.rs
@@ -29,7 +29,7 @@ unsafe extern "C" fn __ykshimtest_tirtrace_new<'a, 'm>(
 /// Returns the length of a SIR trace.
 #[no_mangle]
 unsafe extern "C" fn __ykshimtest_tirtrace_len<'a, 'm>(tir_trace: *mut TirTrace<'a, 'm>) -> size_t {
-    Box::from_raw(tir_trace).len()
+    (*tir_trace).len()
 }
 
 /// Returns the human-readable Display string of a TIR trace.
@@ -37,7 +37,7 @@ unsafe extern "C" fn __ykshimtest_tirtrace_len<'a, 'm>(tir_trace: *mut TirTrace<
 unsafe extern "C" fn __ykshimtest_tirtrace_display<'a, 'm>(
     tir_trace: *mut TirTrace<'a, 'm>,
 ) -> *mut c_char {
-    let tt = Box::from_raw(tir_trace);
+    let tt = &(*tir_trace);
     let st = CString::new(format!("{}", tt)).unwrap();
     CString::into_raw(st)
 }

--- a/tests/src/ykcompile.rs
+++ b/tests/src/ykcompile.rs
@@ -3,8 +3,8 @@ use libc;
 use libc::{abs, c_void, getuid};
 use std::{collections::HashMap, convert::TryFrom, ptr};
 use ykshim_client::{
-    compile_trace, reg_pool_size, sir_body_ret_ty, start_tracing, Local, LocalDecl, LocalIndex,
-    TirTrace, TraceCompiler, TracingKind, TypeId,
+    compile_tir_trace, compile_trace, reg_pool_size, sir_body_ret_ty, start_tracing, Local,
+    LocalDecl, LocalIndex, TirTrace, TraceCompiler, TracingKind, TypeId,
 };
 
 extern "C" {
@@ -736,8 +736,7 @@ fn do_not_trace() {
         &tir_trace,
     );
 
-    // FIXME duplicated work: compile_trace builds tir again.
-    let ct = compile_trace(sir_trace).unwrap();
+    let ct = compile_tir_trace(tir_trace).unwrap();
     let mut args = IO(1);
     assert!(unsafe { ct.execute(&mut args) });
     assert_eq!(args.0, 3);

--- a/ykshim_client/src/lib.rs
+++ b/ykshim_client/src/lib.rs
@@ -2,6 +2,13 @@
 //!
 //! For more information, see this section in the documentation:
 //! https://softdevteam.github.io/ykdocs/tech/yk_structure.html
+//!
+//! Put anything used only in testing in the `test_api` module. Everything else should go in the
+//! `prod_api` module.
+//!
+//! The exception to this rule is `Drop` implementations for opaque pointer wrappers. These should
+//! always go in the `prod_api` module. It's hard to know all of the call sites for `drop()` since
+//! they are implicit, so let's assume the production API does use them.
 
 // FIXME handle all errors that may pass over the API boundary.
 

--- a/ykshim_client/src/prod_api.rs
+++ b/ykshim_client/src/prod_api.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::{mem, ptr};
 
-type RawCompiledTrace = c_void;
+pub(crate) type RawCompiledTrace = c_void;
 pub(crate) type RawSirTrace = c_void;
 type RawThreadTracer = c_void;
 
@@ -87,8 +87,8 @@ impl Drop for SirTrace {
 }
 
 pub struct CompiledTrace<I> {
-    compiled: *mut c_void,
-    _marker: PhantomData<I>,
+    pub(crate) compiled: *mut c_void,
+    pub(crate) _marker: PhantomData<I>,
 }
 
 unsafe impl<I> Send for CompiledTrace<I> {}

--- a/ykshim_client/src/prod_api.rs
+++ b/ykshim_client/src/prod_api.rs
@@ -5,9 +5,11 @@ use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::{mem, ptr};
 
+// Opaque pointers.
 pub(crate) type RawCompiledTrace = c_void;
 pub(crate) type RawSirTrace = c_void;
 type RawThreadTracer = c_void;
+pub(crate) type RawTirTrace = c_void;
 
 // These types and constants must be kept in sync with types of the same name in the internal
 // workspace.

--- a/ykshim_client/src/test_api.rs
+++ b/ykshim_client/src/test_api.rs
@@ -1,11 +1,12 @@
 //! The testing API client to ykshim.
 
-use crate::prod_api::{Local, RawSirTrace, SirTrace, TyIndex};
+use crate::prod_api::{CompiledTrace, Local, RawCompiledTrace, RawSirTrace, SirTrace, TyIndex};
 use libc::size_t;
 use std::collections::HashMap;
 use std::ffi::{c_void, CString};
-use std::fmt;
+use std::marker::PhantomData;
 use std::os::raw::c_char;
+use std::{fmt, ptr};
 
 // Opaque pointers.
 type RawTirTrace = c_void;
@@ -19,6 +20,7 @@ pub struct CguHash(u64);
 pub type TypeId = (CguHash, TyIndex);
 
 extern "C" {
+    fn __ykshimtest_compile_tir_trace(tir_trace: *mut RawTirTrace) -> *mut RawCompiledTrace;
     fn __ykshimtest_sirtrace_len(sir_trace: *mut RawSirTrace) -> size_t;
     fn __ykshimtest_tirtrace_new(sir_trace: *mut RawSirTrace) -> *mut RawTirTrace;
     fn __ykshimtest_tracecompiler_drop(comp: *mut RawTraceCompiler);
@@ -43,6 +45,7 @@ extern "C" {
     fn __ykshimtest_reg_pool_size() -> usize;
 }
 
+#[derive(Debug)]
 pub struct TirTrace(*mut RawTirTrace);
 
 impl TirTrace {
@@ -135,4 +138,13 @@ pub fn interpret_body<I>(body_name: &str, icx: &mut I) {
 
 pub fn reg_pool_size() -> usize {
     unsafe { __ykshimtest_reg_pool_size() }
+}
+
+pub fn compile_tir_trace<T>(mut tir_trace: TirTrace) -> Result<CompiledTrace<T>, CString> {
+    let compiled = unsafe { __ykshimtest_compile_tir_trace(tir_trace.0) };
+    tir_trace.0 = ptr::null_mut(); // consumed.
+    Ok(CompiledTrace {
+        compiled,
+        _marker: PhantomData,
+    })
 }


### PR DESCRIPTION
Fix some memory safety issues, and remove duplication of compilation from a test.

This shouldn't get in the way of the black-hole work.