### PR TITLE
Rename IO to InterpCtx

### DIFF
--- a/internal_ws/ykbh/src/lib.rs
+++ b/internal_ws/ykbh/src/lib.rs
@@ -194,9 +194,8 @@ impl SIRInterpreter {
     /// Run the SIR interpreter after it has been initialised by a guard failure. Since we start in
     /// the block where the guard failed, we immediately skip to the terminator and interpret it to
     /// see which block we need to start interpretation in.
-    pub unsafe fn interpret(&mut self, tio: *mut u8) {
-        // Set the pointer to the trace ctx.
-        self.set_trace_ctx(tio);
+    pub unsafe fn interpret(&mut self, ctx: *mut u8) {
+        self.set_interp_ctx(ctx);
         // Jump to the correct basic block by interpreting the terminator.
         let frame = self.frames.last().unwrap();
         let body = SIR.body(&frame.func).unwrap();
@@ -231,13 +230,13 @@ impl SIRInterpreter {
         &self.frames.last().unwrap().mem
     }
 
-    /// Inserts a pointer to the trace context into the `interp_step` frame.
-    pub fn set_trace_ctx(&mut self, tio: *mut u8) {
-        // The trace context live in $1
+    /// Inserts a pointer to the interpreter context into the `interp_step` frame.
+    pub fn set_interp_ctx(&mut self, ctx: *mut u8) {
+        // The interpreter context lives in $1
         let ptr = self.frames.first().unwrap().mem.local_ptr(&Local(1));
         unsafe {
             // Write the pointer value of `tio` into this frames memory.
-            std::ptr::write::<*mut u8>(ptr as *mut *mut u8, tio);
+            std::ptr::write::<*mut u8>(ptr as *mut *mut u8, ctx);
         }
     }
 

--- a/internal_ws/ykbh/src/lib.rs
+++ b/internal_ws/ykbh/src/lib.rs
@@ -195,8 +195,8 @@ impl SIRInterpreter {
     /// the block where the guard failed, we immediately skip to the terminator and interpret it to
     /// see which block we need to start interpretation in.
     pub unsafe fn interpret(&mut self, tio: *mut u8) {
-        // Set the pointer to the trace inputs.
-        self.set_trace_inputs(tio);
+        // Set the pointer to the trace ctx.
+        self.set_trace_ctx(tio);
         // Jump to the correct basic block by interpreting the terminator.
         let frame = self.frames.last().unwrap();
         let body = SIR.body(&frame.func).unwrap();
@@ -231,9 +231,9 @@ impl SIRInterpreter {
         &self.frames.last().unwrap().mem
     }
 
-    /// Inserts a pointer to the trace inputs into the `interp_step` frame.
-    pub fn set_trace_inputs(&mut self, tio: *mut u8) {
-        // The trace inputs live in $1
+    /// Inserts a pointer to the trace context into the `interp_step` frame.
+    pub fn set_trace_ctx(&mut self, tio: *mut u8) {
+        // The trace context live in $1
         let ptr = self.frames.first().unwrap().mem.local_ptr(&Local(1));
         unsafe {
             // Write the pointer value of `tio` into this frames memory.

--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -54,7 +54,7 @@ lazy_static! {
 
     // The interpreter context is always allocated to this reserved register.
     // This register should not appear in REG_POOL.
-    static ref TIO_REG: u8 = RDI.code();
+    static ref ICTX_REG: u8 = RDI.code();
 
     static ref TEMP_LOC: Location = Location::Reg(*TEMP_REG);
     static ref PTR_SIZE: u64 = u64::try_from(mem::size_of::<usize>()).unwrap();
@@ -520,8 +520,8 @@ impl TraceCompiler {
     /// performs one.
     pub fn local_to_location(&mut self, l: Local) -> Location {
         if l == INTERP_STEP_ARG {
-            // There is a register set aside for the trace context.
-            Location::Reg(*TIO_REG)
+            // There is a register set aside for the interpreter context.
+            Location::Reg(*ICTX_REG)
         } else if let Some(location) = self.variable_location_map.get(&l) {
             // We already have a location for this local.
             location.clone()
@@ -579,10 +579,10 @@ impl TraceCompiler {
             Location::Reg(reg) => {
                 // This local is currently stored in a register, so free the register.
                 //
-                // Note that if we are marking the reserved TIO_REG free then this actually adds a
+                // Note that if we are marking the reserved ICTX_REG free then this actually adds a
                 // new register key to the map (as opposed to marking a pre-existing entry free).
-                // This is safe since if we are freeing TIO_REG, then the trace context local must
-                // not be used for the remainder of the trace.
+                // This is safe since if we are freeing ICTX_REG, then the interpreter context
+                // local must not be used for the remainder of the trace.
                 self.register_content_map.insert(*reg, RegAlloc::Free);
             }
             Location::Mem { .. } | Location::Indirect { .. } => {}

--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -52,7 +52,7 @@ lazy_static! {
                                      R10.code(), RBX.code(), R12.code(), R13.code(), R14.code(),
                                      R15.code()];
 
-    // The trace inputs/outputs are always allocated to this reserved register.
+    // The interpreter context is always allocated to this reserved register.
     // This register should not appear in REG_POOL.
     static ref TIO_REG: u8 = RDI.code();
 
@@ -520,7 +520,7 @@ impl TraceCompiler {
     /// performs one.
     pub fn local_to_location(&mut self, l: Local) -> Location {
         if l == INTERP_STEP_ARG {
-            // There is a register set aside for trace inputs.
+            // There is a register set aside for the trace context.
             Location::Reg(*TIO_REG)
         } else if let Some(location) = self.variable_location_map.get(&l) {
             // We already have a location for this local.
@@ -581,7 +581,7 @@ impl TraceCompiler {
                 //
                 // Note that if we are marking the reserved TIO_REG free then this actually adds a
                 // new register key to the map (as opposed to marking a pre-existing entry free).
-                // This is safe since if we are freeing TIO_REG, then the trace inputs local must
+                // This is safe since if we are freeing TIO_REG, then the trace context local must
                 // not be used for the remainder of the trace.
                 self.register_content_map.insert(*reg, RegAlloc::Free);
             }

--- a/internal_ws/ykshim/src/prod_api.rs
+++ b/internal_ws/ykshim/src/prod_api.rs
@@ -109,9 +109,9 @@ unsafe fn __ykshim_tirtrace_drop(tir_trace: *mut TirTrace) {
 
 /// Start an initialised SIRInterpreter.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_si_interpret(si: *mut ykbh::SIRInterpreter, icx: *mut u8) {
+unsafe extern "C" fn __ykshim_si_interpret(si: *mut ykbh::SIRInterpreter, ctx: *mut u8) {
     let si = &mut *si;
-    si.interpret(icx);
+    si.interpret(ctx);
 }
 
 #[no_mangle]

--- a/internal_ws/ykshim/src/test_api.rs
+++ b/internal_ws/ykshim/src/test_api.rs
@@ -111,10 +111,10 @@ unsafe extern "C" fn __ykshimtest_tracecompiler_find_sym(sym: *mut c_char) -> *m
 
 /// Interpret a SIR body with the specified interpreter context.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *mut c_char, icx: *mut u8) {
+unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *mut c_char, ctx: *mut u8) {
     let fname = CString::from_raw(body_name).to_str().unwrap().to_string();
     let mut si = SIRInterpreter::new(fname);
-    si.set_trace_inputs(icx);
+    si.set_interp_ctx(ctx);
     si._interpret();
 }
 

--- a/tests/src/guardfailure.rs
+++ b/tests/src/guardfailure.rs
@@ -18,15 +18,15 @@ fn simple() {
         io.1 = x;
     }
 
-    let mut inputs = IO(std::hint::black_box(|i| i)(0), 0);
+    let mut ctx = IO(std::hint::black_box(|i| i)(0), 0);
     let th = start_tracing(TracingKind::HardwareTracing);
-    interp_step(&mut inputs);
+    interp_step(&mut ctx);
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0, 0);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 9);
-    // Execute trace with input that fails the guard.
+    // Execute the trace with the context that caused the guard to fail.
     let mut args = IO(3, 0);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());
@@ -60,15 +60,15 @@ fn recursion() {
         io.1 = x;
     }
 
-    let mut inputs = IO(std::hint::black_box(|i| i)(0), 0);
+    let mut ctx = IO(std::hint::black_box(|i| i)(0), 0);
     let th = start_tracing(TracingKind::HardwareTracing);
-    interp_step(&mut inputs);
+    interp_step(&mut ctx);
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(0, 0);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 1);
-    // Execute trace with input that fails the guard.
+    // Execute the trace with the context that caused the guard to fail.
     let mut args = IO(0, 1);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());
@@ -98,15 +98,15 @@ fn recursion2() {
         io.1 = x;
     }
 
-    let mut inputs = IO(7, 0);
+    let mut ctx = IO(7, 0);
     let th = start_tracing(TracingKind::HardwareTracing);
-    interp_step(&mut inputs);
+    interp_step(&mut ctx);
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
     let mut args = IO(7, 1);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 1);
-    // Execute trace with input that fails the guard.
+    // Execute the trace with the context that caused the guard to fail.
     let mut args = IO(1, 0);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());

--- a/tests/src/guardfailure.rs
+++ b/tests/src/guardfailure.rs
@@ -2,7 +2,7 @@ use ykshim_client::{compile_trace, start_tracing, SIRInterpreter, TracingKind};
 
 #[test]
 fn simple() {
-    struct IO(u8, u8);
+    struct InterpCtx(u8, u8);
 
     fn guard(i: u8) -> u8 {
         if i != 3 {
@@ -13,21 +13,21 @@ fn simple() {
     }
 
     #[interp_step]
-    fn interp_step(io: &mut IO) {
+    fn interp_step(io: &mut InterpCtx) {
         let x = guard(io.0);
         io.1 = x;
     }
 
-    let mut ctx = IO(std::hint::black_box(|i| i)(0), 0);
+    let mut ctx = InterpCtx(std::hint::black_box(|i| i)(0), 0);
     let th = start_tracing(TracingKind::HardwareTracing);
     interp_step(&mut ctx);
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
-    let mut args = IO(0, 0);
+    let mut args = InterpCtx(0, 0);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 9);
-    // Execute the trace with the context that caused the guard to fail.
-    let mut args = IO(3, 0);
+    // Execute the trace with a context that causes a guard to fail.
+    let mut args = InterpCtx(3, 0);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());
     // Check that running the interpreter gets us the correct result.
@@ -38,7 +38,7 @@ fn simple() {
 
 #[test]
 fn recursion() {
-    struct IO(u8, u8);
+    struct InterpCtx(u8, u8);
 
     // Test that if a guard fails within a recursive call, we still construct the correct stack
     // frames for the blackholing interpreter.
@@ -55,21 +55,21 @@ fn recursion() {
     }
 
     #[interp_step]
-    fn interp_step(io: &mut IO) {
+    fn interp_step(io: &mut InterpCtx) {
         let x = rec(io.0, io.1);
         io.1 = x;
     }
 
-    let mut ctx = IO(std::hint::black_box(|i| i)(0), 0);
+    let mut ctx = InterpCtx(std::hint::black_box(|i| i)(0), 0);
     let th = start_tracing(TracingKind::HardwareTracing);
     interp_step(&mut ctx);
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
-    let mut args = IO(0, 0);
+    let mut args = InterpCtx(0, 0);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 1);
-    // Execute the trace with the context that caused the guard to fail.
-    let mut args = IO(0, 1);
+    // Execute the trace with a context that causes a guard to fail.
+    let mut args = InterpCtx(0, 1);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());
     // Check that running the interpreter gets us the correct result.
@@ -81,7 +81,7 @@ fn recursion() {
 #[ignore]
 #[test]
 fn recursion2() {
-    struct IO(u8, u8);
+    struct InterpCtx(u8, u8);
 
     // Test that the SIR interpreter can deal with new recursions after a guard failure.
     fn rec(i: u8, j: u8) -> u8 {
@@ -93,21 +93,21 @@ fn recursion2() {
     }
 
     #[interp_step]
-    fn interp_step(io: &mut IO) {
+    fn interp_step(io: &mut InterpCtx) {
         let x = rec(io.0, io.1);
         io.1 = x;
     }
 
-    let mut ctx = IO(7, 0);
+    let mut ctx = InterpCtx(7, 0);
     let th = start_tracing(TracingKind::HardwareTracing);
     interp_step(&mut ctx);
     let sir_trace = th.stop_tracing().unwrap();
     let ct = compile_trace(sir_trace).unwrap();
-    let mut args = IO(7, 1);
+    let mut args = InterpCtx(7, 1);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args.1, 1);
-    // Execute the trace with the context that caused the guard to fail.
-    let mut args = IO(1, 0);
+    // Execute the trace with a context that causes a guard to fail.
+    let mut args = InterpCtx(1, 0);
     let ptr = unsafe { ct.execute(&mut args) };
     assert!(!ptr.is_null());
     // Check that running the interpreter gets us the correct result.

--- a/tests/src/ykbh.rs
+++ b/tests/src/ykbh.rs
@@ -8,9 +8,9 @@ fn simple() {
         let a = 3;
         io.1 = a;
     }
-    let mut tio = InterpCtx(0, 0);
-    interpret_body("simple", &mut tio);
-    assert_eq!(tio.1, 3);
+    let mut ctx = InterpCtx(0, 0);
+    interpret_body("simple", &mut ctx);
+    assert_eq!(ctx.1, 3);
 }
 
 #[test]
@@ -23,9 +23,9 @@ fn tuple() {
         (io.0).1 = b;
     }
 
-    let mut tio = InterpCtx((1, 2, 3));
-    interpret_body("func_tuple", &mut tio);
-    assert_eq!(tio.0, (1, 3, 3));
+    let mut ctx = InterpCtx((1, 2, 3));
+    interpret_body("func_tuple", &mut ctx);
+    assert_eq!(ctx.0, (1, 3, 3));
 }
 
 #[test]
@@ -38,9 +38,9 @@ fn reference() {
         io.1 = *b;
     }
 
-    let mut tio = InterpCtx(5, 0);
-    interpret_body("func_ref", &mut tio);
-    assert_eq!(tio.1, 5);
+    let mut ctx = InterpCtx(5, 0);
+    interpret_body("func_ref", &mut ctx);
+    assert_eq!(ctx.1, 5);
 }
 
 #[test]
@@ -54,9 +54,9 @@ fn tupleref() {
         (io.0).0 = b.1;
     }
 
-    let mut tio = InterpCtx((0, 3));
-    interpret_body("func_tupleref", &mut tio);
-    assert_eq!(tio.0, (3, 5));
+    let mut ctx = InterpCtx((0, 3));
+    interpret_body("func_tupleref", &mut ctx);
+    assert_eq!(ctx.0, (3, 5));
 }
 
 #[test]
@@ -68,9 +68,9 @@ fn doubleref() {
         (io.0).0 = a.1;
     }
 
-    let mut tio = InterpCtx((0, 3));
-    interpret_body("func_doubleref", &mut tio);
-    assert_eq!(tio.0, (3, 3));
+    let mut ctx = InterpCtx((0, 3));
+    interpret_body("func_doubleref", &mut ctx);
+    assert_eq!(ctx.0, (3, 3));
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn call() {
         io.0 = a;
     }
 
-    let mut tio = InterpCtx(0, 0);
-    interpret_body("func_call", &mut tio);
-    assert_eq!(tio.0, 5);
+    let mut ctx = InterpCtx(0, 0);
+    interpret_body("func_call", &mut ctx);
+    assert_eq!(ctx.0, 5);
 }

--- a/tests/src/ykbh.rs
+++ b/tests/src/ykbh.rs
@@ -2,92 +2,92 @@ use ykshim_client::interpret_body;
 
 #[test]
 fn simple() {
-    struct IO(u8, u8);
+    struct InterpCtx(u8, u8);
     #[no_mangle]
-    fn simple(io: &mut IO) {
+    fn simple(io: &mut InterpCtx) {
         let a = 3;
         io.1 = a;
     }
-    let mut tio = IO(0, 0);
+    let mut tio = InterpCtx(0, 0);
     interpret_body("simple", &mut tio);
     assert_eq!(tio.1, 3);
 }
 
 #[test]
 fn tuple() {
-    struct IO((u8, u8, u8));
+    struct InterpCtx((u8, u8, u8));
     #[no_mangle]
-    fn func_tuple(io: &mut IO) {
+    fn func_tuple(io: &mut InterpCtx) {
         let a = io.0;
         let b = a.2;
         (io.0).1 = b;
     }
 
-    let mut tio = IO((1, 2, 3));
+    let mut tio = InterpCtx((1, 2, 3));
     interpret_body("func_tuple", &mut tio);
     assert_eq!(tio.0, (1, 3, 3));
 }
 
 #[test]
 fn reference() {
-    struct IO(u8, u8);
+    struct InterpCtx(u8, u8);
     #[no_mangle]
-    fn func_ref(io: &mut IO) {
+    fn func_ref(io: &mut InterpCtx) {
         let a = 5u8;
         let b = &a;
         io.1 = *b;
     }
 
-    let mut tio = IO(5, 0);
+    let mut tio = InterpCtx(5, 0);
     interpret_body("func_ref", &mut tio);
     assert_eq!(tio.1, 5);
 }
 
 #[test]
 fn tupleref() {
-    struct IO((u8, u8));
+    struct InterpCtx((u8, u8));
     #[no_mangle]
-    fn func_tupleref(io: &mut IO) {
+    fn func_tupleref(io: &mut InterpCtx) {
         let a = io.0;
         (io.0).1 = 5; // Make sure the line above copies.
         let b = &a;
         (io.0).0 = b.1;
     }
 
-    let mut tio = IO((0, 3));
+    let mut tio = InterpCtx((0, 3));
     interpret_body("func_tupleref", &mut tio);
     assert_eq!(tio.0, (3, 5));
 }
 
 #[test]
 fn doubleref() {
-    struct IO((u8, u8));
+    struct InterpCtx((u8, u8));
     #[no_mangle]
-    fn func_doubleref(io: &mut IO) {
+    fn func_doubleref(io: &mut InterpCtx) {
         let a = &io.0;
         (io.0).0 = a.1;
     }
 
-    let mut tio = IO((0, 3));
+    let mut tio = InterpCtx((0, 3));
     interpret_body("func_doubleref", &mut tio);
     assert_eq!(tio.0, (3, 3));
 }
 
 #[test]
 fn call() {
-    struct IO(u8, u8);
+    struct InterpCtx(u8, u8);
 
     fn foo(i: u8) -> u8 {
         i
     }
 
     #[no_mangle]
-    fn func_call(io: &mut IO) {
+    fn func_call(io: &mut InterpCtx) {
         let a = foo(5);
         io.0 = a;
     }
 
-    let mut tio = IO(0, 0);
+    let mut tio = InterpCtx(0, 0);
     interpret_body("func_call", &mut tio);
     assert_eq!(tio.0, 5);
 }

--- a/tests/src/ykcompile.rs
+++ b/tests/src/ykcompile.rs
@@ -135,7 +135,7 @@ fn reg_alloc() {
 #[test]
 fn reg_alloc_spills() {
     let types = TestTypes::new();
-    let num_regs = reg_pool_size() + 1; // Plus one for TIO_REG.
+    let num_regs = reg_pool_size() + 1; // Plus one for ICTX_REG.
     let num_spills = 16;
     let num_decls = num_regs + num_spills;
     let mut local_decls = HashMap::new();
@@ -164,7 +164,7 @@ fn reg_alloc_spills() {
 #[test]
 fn reg_alloc_spills_and_frees() {
     let types = TestTypes::new();
-    let num_regs = reg_pool_size() + 1; // Plus one for TIO_REG.
+    let num_regs = reg_pool_size() + 1; // Plus one for ICTX_REG.
     let num_decls = num_regs + 4;
     let mut local_decls = HashMap::new();
     for i in 0..num_decls {

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -179,7 +179,7 @@ impl MTThread {
         &mut self,
         loc: Option<&Location<I>>,
         step_fn: S,
-        inputs: &mut I,
+        ctx: &mut I,
     ) where
         S: Fn(&mut I),
     {
@@ -187,27 +187,27 @@ impl MTThread {
         // this thread's tracer.
         if let Some(loc) = loc {
             if let Some(func) = self.transition_location::<I>(loc) {
-                let ptr = self.exec_trace(func, inputs);
+                let ptr = self.exec_trace(func, ctx);
                 if ptr.is_null() {
                     // Trace succesfully executed.
                     return;
                 } else {
                     unsafe {
                         let mut si = SIRInterpreter(ptr);
-                        si.interpret(inputs as *mut _ as *mut u8);
+                        si.interpret(ctx as *mut _ as *mut u8);
                     }
                 }
             }
         }
-        step_fn(inputs)
+        step_fn(ctx)
     }
 
     fn exec_trace<I>(
         &mut self,
         func: fn(&mut I) -> *mut RawSIRInterpreter,
-        inputs: &mut I,
+        ctx: &mut I,
     ) -> *mut RawSIRInterpreter {
-        func(inputs)
+        func(ctx)
     }
 
     /// `Location`s represent a statemachine: this function transitions to the next state (which
@@ -471,7 +471,7 @@ mod tests {
     struct DummyIO {}
 
     #[interp_step]
-    fn dummy_step(_inputs: &mut DummyIO) {}
+    fn dummy_step(_: &mut DummyIO) {}
 
     #[test]
     fn threshold_passed() {

--- a/ykshim_client/src/prod_api.rs
+++ b/ykshim_client/src/prod_api.rs
@@ -35,7 +35,7 @@ extern "C" {
     fn __ykshim_compiled_trace_get_ptr(compiled_trace: *const RawCompiledTrace) -> *const c_void;
     fn __ykshim_compiled_trace_drop(compiled_trace: *mut RawCompiledTrace);
     fn __ykshim_sirtrace_drop(trace: *mut RawSirTrace);
-    fn __ykshim_si_interpret(interp: *mut RawSIRInterpreter, icx: *mut u8);
+    fn __ykshim_si_interpret(interp: *mut RawSIRInterpreter, ctx: *mut u8);
     fn __ykshim_sirinterpreter_drop(interp: *mut RawSIRInterpreter);
 }
 
@@ -134,9 +134,9 @@ impl<I> CompiledTrace<I> {
     }
 
     /// Execute the trace with the given interpreter context.
-    pub unsafe fn execute(&self, icx: &mut I) -> *mut RawSIRInterpreter {
+    pub unsafe fn execute(&self, ctx: &mut I) -> *mut RawSIRInterpreter {
         let f = mem::transmute::<_, fn(&mut I) -> *mut RawSIRInterpreter>(self.ptr());
-        f(icx)
+        f(ctx)
     }
 }
 

--- a/ykshim_client/src/prod_api.rs
+++ b/ykshim_client/src/prod_api.rs
@@ -83,8 +83,8 @@ impl Drop for ThreadTracer {
 pub struct SIRInterpreter(pub *mut RawSIRInterpreter);
 
 impl SIRInterpreter {
-    pub unsafe fn interpret(&mut self, tio: *mut u8) {
-        __ykshim_si_interpret(self.0, tio);
+    pub unsafe fn interpret(&mut self, ctx: *mut u8) {
+        __ykshim_si_interpret(self.0, ctx);
     }
 }
 

--- a/ykshim_client/src/test_api.rs
+++ b/ykshim_client/src/test_api.rs
@@ -46,7 +46,7 @@ extern "C" {
     ) -> *mut c_char;
     fn __ykshimtest_tracecompiler_local_dead(tc: *mut RawTraceCompiler, local: Local);
     fn __ykshimtest_tracecompiler_find_sym(sym: *mut c_char) -> *mut c_void;
-    fn __ykshimtest_interpret_body(body_name: *mut c_char, icx: *mut u8);
+    fn __ykshimtest_interpret_body(body_name: *mut c_char, ctx: *mut u8);
     fn __ykshimtest_reg_pool_size() -> usize;
 }
 
@@ -138,9 +138,9 @@ impl SirTrace {
     }
 }
 
-pub fn interpret_body<I>(body_name: &str, icx: &mut I) {
+pub fn interpret_body<I>(body_name: &str, ctx: &mut I) {
     let body_cstr = CString::new(body_name).unwrap();
-    unsafe { __ykshimtest_interpret_body(body_cstr.into_raw(), icx as *mut _ as *mut u8) };
+    unsafe { __ykshimtest_interpret_body(body_cstr.into_raw(), ctx as *mut _ as *mut u8) };
 }
 
 pub fn reg_pool_size() -> usize {


### PR DESCRIPTION
We previously used the term `IO` (and, occasionally, `WorkIO`) and the term "input" (and, occasionally, "inputs") to refer to the data structure passed to an interp_step. This was confusing (IO generally means files), and we weren't consistent. This PR is a minimal-ish attempt to tidy it up.

However, normally I'd just say "this is a mechanical renaming, don't worry too much about it." However, I had to do quite a bit in https://github.com/softdevteam/yk/commit/fb7cf61dabaea46b3a96408a3b9933d0b625962a and https://github.com/softdevteam/yk/commit/9b5fd41ab625fbe6d7437fc2b45f5cb13b08a22f by hand (though https://github.com/softdevteam/yk/commit/d08bc680fc9fd254bac152d3d4aeeef84f13cc21 and https://github.com/softdevteam/yk/pull/222/commits/0034f518fdd0a91fa047c696dc253f35e899b98b are `srep` jobs), as I also had to adjust comments, so these need checking carefully -- not, probably, for code correctness, but to make sure that I haven't made the code read worse than before!