### PR TITLE
Use underscores more idiomatically.

### DIFF
--- a/internal_ws/ykbh/src/lib.rs
+++ b/internal_ws/ykbh/src/lib.rs
@@ -53,7 +53,7 @@ impl LocalMem {
                     }
                     _ => todo!(),
                 },
-                ConstantInt::SignedInt(_si) => todo!(),
+                ConstantInt::SignedInt(_) => todo!(),
             },
             Constant::Bool(b) => self.write_val(dest, [*b as u8].as_ptr(), 1),
             Constant::Tuple(t) => {
@@ -341,7 +341,7 @@ impl SIRInterpreter {
                 UnsignedIntTy::U64 => todo!(),
                 UnsignedIntTy::U128 => todo!(),
             },
-            TyKind::SignedInt(_si) => unreachable!(),
+            TyKind::SignedInt(_) => unreachable!(),
             TyKind::Bool => unsafe { u128::from(std::ptr::read::<u8>(ptr)) },
             _ => unreachable!(),
         }

--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -633,13 +633,6 @@ impl TraceCompiler {
         self.restore_regs(&*CALLER_SAVED_REGS);
     }
 
-    /// Emit a NOP operation.
-    fn _nop(&mut self) {
-        dynasm!(self.asm
-            ; nop
-        );
-    }
-
     /// Push the specified registers to the stack in order.
     fn save_regs(&mut self, regs: &[u8]) {
         for reg in regs.iter() {

--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -311,7 +311,7 @@ pub extern "sysv64" fn bh_push_vec(
 /// Compile a TIR trace, returning executable code.
 pub fn compile_trace(tt: TirTrace) -> CompiledTrace {
     CompiledTrace {
-        mc: TraceCompiler::_compile(tt, false),
+        mc: TraceCompiler::compile(tt, false),
     }
 }
 
@@ -1172,7 +1172,7 @@ impl TraceCompiler {
                     _ => todo!("{}", ty.size()),
                 }
             }
-            Location::Mem(_ro) => todo!(),
+            Location::Mem(_) => todo!(),
             Location::Indirect { .. } => todo!(),
             Location::Const { .. } => todo!(),
         }
@@ -1519,7 +1519,7 @@ impl TraceCompiler {
         );
     }
 
-    fn _compile(mut tt: TirTrace, debug: bool) -> dynasmrt::ExecutableBuffer {
+    fn compile(mut tt: TirTrace, debug: bool) -> dynasmrt::ExecutableBuffer {
         let mut tc: Self = TraceCompiler::new(
             tt.local_decls.clone(),
             tt.addr_map.drain().into_iter().collect(),


### PR DESCRIPTION
It's a bit odd to see variables starting with underscores outside of method parameters.