### PR TITLE
Allow yk to be consumed like a normal Rust dependency.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -14,7 +14,7 @@ RUSTFLAGS="${RUSTFLAGS} -D warnings"
 tar jxf /opt/ykrustc-bin-snapshots/ykrustc-${STD_TRACER_MODE}-stage2-latest.tar.bz2
 export PATH=`pwd`/ykrustc-stage2-latest/bin:${PATH}
 
-cargo xtask test
+RUSTFLAGS="-C tracer=${STD_TRACER_MODE}" cargo xtask test
 
 export CARGO_HOME="`pwd`/.cargo"
 export RUSTUP_HOME="`pwd`/.rustup"
@@ -28,4 +28,3 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu \
 export PATH=${CARGO_HOME}/bin/:$PATH
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo xtask fmt --all -- --check
-cd internal_ws && cargo +nightly fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@ The compiler repo can be found [here](https://github.com/softdevteam/ykrustc).
 To get started, see
 [this section in the documentation](https://softdevteam.github.io/ykdocs/dev/getting_started.html).
 
-This repo uses xtask instead of regular cargo, so instead of running `cargo
-<target>`, you will instead need to execute `cargo xtask <target>`.
+To work with this repository, instead of running `cargo <target>`, instead
+execute `cargo xtask <target>`.
+
+You will also need to add the `-C tracer=<kind>` flag to `RUSTFLAGS` to tell
+the build system what kind of tracer you want to use (`hw` or `sw`, although
+only `hw` works at the moment).
+
+For example, to test using hardware tracing:
+```
+$ export RUSTFLAGS="-C tracer=hw"
+$ cargo xtask test
+```
 
 ## Contributors
 

--- a/build_aux.rs
+++ b/build_aux.rs
@@ -1,0 +1,18 @@
+// Code shared by `ykrt/build.rs` and `xtask/src/main.rs`.
+
+/// Determine what kind of tracing the user has requested at compile time, by looking at RUSTFLAGS.
+/// Ideally, we'd have the user set another environment variable, and then set RUSTFLAGS
+/// accordingly, but you cant' set arbitrary RUSTFLAGS from build.rs.
+fn find_tracing_kind(rustflags: &str) -> String {
+    let re = Regex::new(r"-C\s*tracer=([a-z]*)").unwrap();
+    let mut cgs = re.captures_iter(&rustflags);
+    let tracing_kind = if let Some(caps) = cgs.next() {
+        caps.get(1).unwrap().as_str()
+    } else {
+        panic!("Please choose a tracer by setting `RUSTFLAGS=\"-C tracer=<kind>\"`.");
+    };
+    if cgs.next().is_some() {
+        panic!("`-C tracer=<kind>` was specified more than once in $RUSTFLAGS");
+    }
+    tracing_kind.to_owned()
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["The Yorick Developers"]
 edition = "2018"
 
 [dependencies]
+regex = "1.4.3"

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -7,3 +7,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 ykshim_client = { path = "../ykshim_client" }
+
+[build-dependencies]
+regex = "1.4.3"

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -1,6 +1,61 @@
+use regex::Regex;
 use std::env;
+use std::os::unix::fs::symlink;
+use std::path::PathBuf;
+use std::process::Command;
+
+include!("../build_aux.rs");
+
+const YKSHIM_SO: &str = "libykshim.so";
 
 fn main() {
+    let ykrt_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let mut internal_dir = ykrt_dir.clone();
+    internal_dir.push("..");
+    internal_dir.push("internal_ws");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let cargo = env::var("CARGO").unwrap();
+    let rust_flags = env::var("RUSTFLAGS").unwrap_or_else(|_| String::new());
+    let tracing_kind = find_tracing_kind(&rust_flags);
+
+    // Only build the internal workspace now if we are not using xtask, i.e. if we are being
+    // consumed as a dependency. This means we see the compiler output for the internal workspace
+    // correctly when working directly with the yk repo (via xtask).
+    if env::var("YK_XTASK").is_err() {
+        let status = Command::new(cargo)
+            .current_dir(&internal_dir)
+            .arg("build")
+            .arg("--release")
+            .env(
+                "RUSTFLAGS",
+                &format!("--cfg tracermode=\"{}\"", tracing_kind),
+            )
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
+        if !status.success() {
+            eprintln!("building internal workspace failed");
+            std::process::exit(1);
+        }
+    }
+
+    // If we symlink libykshim.so into the target dir, then this is already in the linker path when
+    // run under cargo. In other words, the user won't have to set LD_LIBRARY_PATH.
+    let mut sym_dest = out_dir.clone();
+    sym_dest.push("..");
+    sym_dest.push("..");
+    sym_dest.push("..");
+    sym_dest.push(YKSHIM_SO);
+    if !PathBuf::from(&sym_dest).exists() {
+        let mut sym_src = internal_dir.clone();
+        sym_src.push("target");
+        sym_src.push("release");
+        sym_src.push(YKSHIM_SO);
+        dbg!(&sym_src, &sym_dest);
+        symlink(sym_src, sym_dest).unwrap();
+    }
+
     println!(
         "cargo:rustc-link-search={}/../internal_ws/target/release/",
         env::current_dir().unwrap().to_str().unwrap()

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -4,7 +4,7 @@ mod location;
 pub mod mt;
 
 pub use self::location::Location;
-pub use self::mt::MT;
+pub use self::mt::{MTBuilder, MT};
 
 /// A debugging aid for traces.
 /// Calls to this function are recognised by Yorick and a special debug TIR statement is inserted


### PR DESCRIPTION
For the `cargo build` target, we can make `build.rs` recursively run
`cargo build` in the internal workspace and then symlink `libykshim.so`
into the consumer's target directory. This avoids the need for consumers
to have special build logic.

We have to keep xtask around for running other targets
(`test`/`fmt`/...) recursively on both workspaces. I had hoped to have
`build.rs` do this automatically too, but we would need to know which
target has been requested and this information isn't exposed to
`build.rs`.

Tested with `ykbf`, which can now be built with simply:
```
RUSTFLAGS="-C tracer=hw" cargo build
```

Whereas previous attempts had tried using complicated wrapper scripts,
which each consumer in turn would need to duplicate.