### PR TITLE
Sir build utils

### DIFF
--- a/internal_ws/ykpack/Cargo.toml
+++ b/internal_ws/ykpack/Cargo.toml
@@ -10,4 +10,17 @@ bincode = "1.3.1"
 bitflags = "1.2.1"
 fallible-iterator = "0.2.0"
 fxhash = "0.2.1"
+gimli = { version = "0.23.0", optional = true }
 serde = { version = "1.0.118", features = ["derive"] }
+indexmap = { version = "1.5.2", optional = true }
+tempfile = { version = "3.1", optional = true }
+memmap = { version = "0.7", optional = true }
+
+[dependencies.object]
+version = "0.22.0"
+default-features = false
+features = ["read_core", "elf"]
+optional = true
+
+[features]
+write_utils = ["gimli", "tempfile", "memmap", "object", "indexmap"]

--- a/internal_ws/ykpack/src/build.rs
+++ b/internal_ws/ykpack/src/build.rs
@@ -1,0 +1,154 @@
+//! Various utilities for building SIR.
+//!
+//! This code is intended for consumption by Rust code generator backends. By making these
+//! utilities public we avoid the need for code duplication in each backend that wishes to
+//! generate SIR.
+
+use indexmap::IndexMap;
+use std::{cell::RefCell, convert::TryFrom, default::Default, io};
+
+use crate::{
+    BasicBlock, BasicBlockIndex, Body, BodyFlags, CguHash, IPlace, Local, LocalDecl, Statement,
+    Terminator, Ty, TyIndex, TypeId,
+};
+
+/// A collection of in-memory SIR data structures to be serialised.
+/// Each codegen unit builds one instance of this which is then merged into a "global" instance
+/// when the unit completes.
+pub struct Sir {
+    pub types: RefCell<SirTypes>,
+    pub funcs: RefCell<Vec<Body>>,
+}
+
+impl Sir {
+    pub fn new(cgu_hash: CguHash) -> Self {
+        Sir {
+            types: RefCell::new(SirTypes {
+                cgu_hash,
+                map: Default::default(),
+                next_idx: TyIndex(0),
+            }),
+            funcs: Default::default(),
+        }
+    }
+
+    /// Returns true if there is nothing inside.
+    pub fn is_empty(&self) -> bool {
+        self.funcs.borrow().len() == 0
+    }
+
+    /// Writes a textual representation of the SIR to `w`. Used for `--emit yk-sir`.
+    pub fn dump(&self, w: &mut dyn io::Write) -> Result<(), io::Error> {
+        for f in self.funcs.borrow().iter() {
+            writeln!(w, "{}", f)?;
+        }
+        Ok(())
+    }
+}
+
+/// A structure for building the SIR of a function.
+pub struct SirBuilder {
+    /// The SIR function we are building.
+    pub func: Body,
+}
+
+impl SirBuilder {
+    pub fn new(symbol_name: String, flags: BodyFlags, num_args: usize, block_count: usize) -> Self {
+        // Since there's a one-to-one mapping between MIR and SIR blocks, we know how many SIR
+        // blocks we will need and can allocate empty SIR blocks ahead of time.
+        let blocks = vec![
+            BasicBlock {
+                stmts: Default::default(),
+                term: Terminator::Unreachable,
+            };
+            block_count
+        ];
+
+        Self {
+            func: Body {
+                symbol_name,
+                blocks,
+                flags,
+                local_decls: Vec::new(),
+                num_args,
+                layout: (0, 0),
+                offsets: Vec::new(),
+            },
+        }
+    }
+
+    /// Returns a zero-offset IPlace for a new SIR local.
+    pub fn new_sir_local(&mut self, sirty: TypeId) -> IPlace {
+        let idx = u32::try_from(self.func.local_decls.len()).unwrap();
+        self.func.local_decls.push(LocalDecl {
+            ty: sirty,
+            referenced: false,
+        });
+        IPlace::Val {
+            local: Local(idx),
+            off: 0,
+            ty: sirty,
+        }
+    }
+
+    /// Tells the tracer codegen that the local `l` is referenced, and that is should be allocated
+    /// directly to the stack and not a register. You can't reference registers.
+    pub fn notify_referenced(&mut self, l: Local) {
+        let idx = usize::try_from(l.0).unwrap();
+        let slot = self.func.local_decls.get_mut(idx).unwrap();
+        slot.referenced = true;
+    }
+
+    /// Returns true if there are no basic blocks.
+    pub fn is_empty(&self) -> bool {
+        self.func.blocks.len() == 0
+    }
+
+    /// Appends a statement to the specified basic block.
+    pub fn push_stmt(&mut self, bb: BasicBlockIndex, stmt: Statement) {
+        self.func.blocks[usize::try_from(bb).unwrap()]
+            .stmts
+            .push(stmt);
+    }
+
+    /// Sets the terminator of the specified block.
+    pub fn set_terminator(&mut self, bb: BasicBlockIndex, new_term: Terminator) {
+        let term = &mut self.func.blocks[usize::try_from(bb).unwrap()].term;
+        // We should only ever replace the default unreachable terminator assigned at allocation time.
+        debug_assert!(*term == Terminator::Unreachable);
+        *term = new_term
+    }
+}
+
+pub struct SirTypes {
+    /// A globally unique identifier for the codegen unit.
+    pub cgu_hash: CguHash,
+    /// Maps types to their index. Ordered by insertion via `IndexMap`.
+    pub map: IndexMap<Ty, TyIndex>,
+    /// The next available type index.
+    next_idx: TyIndex,
+}
+
+impl SirTypes {
+    /// Get the index of a type. If this is the first time we have seen this type, a new index is
+    /// allocated and returned.
+    ///
+    /// Note that the index is only unique within the scope of the current compilation unit.
+    /// To make a globally unique ID, we pair the index with CGU hash (see CguHash).
+    pub fn index(&mut self, t: Ty) -> TyIndex {
+        let next_idx = &mut self.next_idx.0;
+        *self.map.entry(t).or_insert_with(|| {
+            let idx = *next_idx;
+            *next_idx += 1;
+            TyIndex(idx)
+        })
+    }
+
+    /// Given a type id return the corresponding type.
+    pub fn get(&self, tyid: TypeId) -> &Ty {
+        self.map
+            .get_index(usize::try_from(tyid.idx.0).unwrap())
+            .unwrap()
+            .0
+    }
+}

--- a/internal_ws/ykpack/src/labels.rs
+++ b/internal_ws/ykpack/src/labels.rs
@@ -1,0 +1,133 @@
+use object::{Object, ObjectSection};
+use std::{
+    convert::TryFrom,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::{SirLabel, YKLABELS_SECTION};
+
+/// Splits a Yorick mapping label name into its constituent fields.
+fn split_label_name(s: &str) -> (String, u32) {
+    let data: Vec<&str> = s.split(':').collect();
+    debug_assert!(data.len() == 3);
+    let sym = data[1].to_owned();
+    let bb_idx = data[2].parse::<u32>().unwrap();
+    (sym, bb_idx)
+}
+
+/// Add a Yorick label section to the specified executable.
+pub fn add_yk_label_section(exe_path: &Path) {
+    let labels = extract_dwarf_labels(exe_path).unwrap();
+    let mut tempf = tempfile::NamedTempFile::new().unwrap();
+    bincode::serialize_into(&mut tempf, &labels).unwrap();
+    add_section(exe_path, tempf.path());
+}
+
+/// Copies the bytes in `sec_data_path` into a new Yorick label section of an executable.
+fn add_section(exe_path: &Path, sec_data_path: &Path) {
+    let mut out_path = PathBuf::from(exe_path);
+    out_path.set_extension("with_labels");
+    Command::new("objcopy")
+        .args(&[
+            "--add-section",
+            &format!("{}={}", YKLABELS_SECTION, sec_data_path.to_str().unwrap()),
+            "--set-section-flags",
+            &format!("{}=contents,alloc,readonly", YKLABELS_SECTION),
+            exe_path.to_str().unwrap(),
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to insert labels section");
+    std::fs::rename(out_path, exe_path).unwrap();
+}
+
+/// Walks the DWARF tree of the specified executable and extracts Yorick location mapping
+/// labels. Returns an list of labels ordered by file offset (ascending).
+fn extract_dwarf_labels(exe_filename: &Path) -> Result<Vec<SirLabel>, gimli::Error> {
+    let file = fs::File::open(exe_filename).unwrap();
+    let mmap = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let object = object::File::parse(&*mmap).unwrap();
+    let endian = if object.is_little_endian() {
+        gimli::RunTimeEndian::Little
+    } else {
+        gimli::RunTimeEndian::Big
+    };
+    let loader = |id: gimli::SectionId| -> Result<&[u8], gimli::Error> {
+        Ok(object
+            .section_by_name(id.name())
+            .map(|sec| sec.data().expect("failed to decompress section"))
+            .unwrap_or(&[] as &[u8]))
+    };
+    let sup_loader = |_| Ok(&[] as &[u8]);
+    let dwarf_cow = gimli::Dwarf::load(&loader, &sup_loader)?;
+    let borrow_section: &dyn for<'a> Fn(&&'a [u8]) -> gimli::EndianSlice<'a, gimli::RunTimeEndian> =
+        &|section| gimli::EndianSlice::new(section, endian);
+    let dwarf = dwarf_cow.borrow(&borrow_section);
+    let mut iter = dwarf.units();
+    let mut subaddr = None;
+    let mut labels = Vec::new();
+    while let Some(header) = iter.next()? {
+        let unit = dwarf.unit(header)?;
+        let mut entries = unit.entries();
+        while let Some((_, entry)) = entries.next_dfs()? {
+            if entry.tag() == gimli::DW_TAG_subprogram {
+                if let Some(_name) = entry.attr_value(gimli::DW_AT_linkage_name)? {
+                    if let Some(lowpc) = entry.attr_value(gimli::DW_AT_low_pc)? {
+                        if let gimli::AttributeValue::Addr(v) = lowpc {
+                            // We can not accurately insert labels at the beginning of
+                            // functions, because the label is offset by the function headers.
+                            // We thus simply remember the subprogram's address so we can later
+                            // assign it to the first block (ending with '_0') of this
+                            // subprogram.
+                            subaddr = Some(u64::try_from(v).unwrap());
+                        } else {
+                            panic!("Error reading dwarf information. Expected type 'Addr'.")
+                        }
+                    }
+                }
+            } else if entry.tag() == gimli::DW_TAG_label {
+                if let Some(name) = entry.attr_value(gimli::DW_AT_name)? {
+                    if let Some(es) = name.string_value(&dwarf.debug_str) {
+                        let s = es.to_string()?;
+                        if s.starts_with("__YK_") {
+                            if let Some(lowpc) = entry.attr_value(gimli::DW_AT_low_pc)? {
+                                if subaddr.is_some() && s.ends_with("_0") {
+                                    // This is the first block of the subprogram. Assign its
+                                    // label to the subprogram's address.
+                                    let (fsym, bb) = split_label_name(s);
+                                    labels.push(SirLabel {
+                                        off: usize::try_from(subaddr.unwrap()).unwrap(),
+                                        symbol_name: fsym,
+                                        bb,
+                                    });
+                                    subaddr = None;
+                                } else {
+                                    let (fsym, bb) = split_label_name(s);
+                                    if let gimli::AttributeValue::Addr(v) = lowpc {
+                                        labels.push(SirLabel {
+                                            off: usize::try_from(u64::try_from(v).unwrap())
+                                                .unwrap(),
+                                            symbol_name: fsym,
+                                            bb,
+                                        });
+                                    } else {
+                                        panic!(
+                                                "Error reading dwarf information. Expected type 'Addr'."
+                                            );
+                                    }
+                                }
+                            } else {
+                                // Ignore labels that have no address.
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    labels.sort_by_key(|l| l.off);
+    Ok(labels)
+}

--- a/internal_ws/ykpack/src/lib.rs
+++ b/internal_ws/ykpack/src/lib.rs
@@ -21,8 +21,12 @@
 //!  The version field is automatically written and checked by the `Encoder` and `Decoder`
 //!  respectively.
 
+#[cfg(feature = "write_utils")]
+pub mod build;
 mod decode;
 mod encode;
+#[cfg(feature = "write_utils")]
+pub mod labels;
 mod types;
 
 pub use decode::Decoder;


### PR DESCRIPTION
This moves part of cg_ssa/sir.rs to ykpack behind a feature flag. This allows these things to be reused by cg_clif.

This PR can be merged without the accompanying ykrustc PR.