### PR TITLE
Xtask refactor

### DIFF
--- a/build_aux.rs
+++ b/build_aux.rs
@@ -1,18 +1,29 @@
 // Code shared by `ykrt/build.rs` and `xtask/src/main.rs`.
 
-/// Determine what kind of tracing the user has requested at compile time, by looking at RUSTFLAGS.
-/// Ideally, we'd have the user set another environment variable, and then set RUSTFLAGS
-/// accordingly, but you cant' set arbitrary RUSTFLAGS from build.rs.
+/// Determine what kind of tracing the user has requested at compile time, by looking at the output
+/// of `rustc --print cfg`. Ideally, we'd have the user set a environment variable, and then set
+/// RUSTFLAGS accordingly, but you can't set arbitrary RUSTFLAGS from build.rs.
+/// This doesn't look for `-Ctracer` in RUSTFLAGS as different backends may use different methods
+/// of setting the tracing kind.
 fn find_tracing_kind(rustflags: &str) -> String {
-    let re = Regex::new(r"-C\s*tracer=([a-z]*)").unwrap();
-    let mut cgs = re.captures_iter(&rustflags);
+    let cfgs =
+        std::process::Command::new(std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string()))
+            .args(&["--print", "cfg"])
+            .args(rustflags.split(" "))
+            .output()
+            .unwrap()
+            .stdout;
+    let cfgs = String::from_utf8(cfgs).unwrap();
+
+    let re = regex::Regex::new(r#"tracermode="([a-z]*)"\n"#).unwrap();
+    let mut cgs = re.captures_iter(&cfgs);
     let tracing_kind = if let Some(caps) = cgs.next() {
         caps.get(1).unwrap().as_str()
     } else {
         panic!("Please choose a tracer by setting `RUSTFLAGS=\"-C tracer=<kind>\"`.");
     };
     if cgs.next().is_some() {
-        panic!("`-C tracer=<kind>` was specified more than once in $RUSTFLAGS");
+        panic!("Tracer mode was specified more than once in $RUSTFLAGS");
     }
     tracing_kind.to_owned()
 }
@@ -20,6 +31,6 @@ fn find_tracing_kind(rustflags: &str) -> String {
 /// Given the RUSTFLAGS for the external workspace, make flags for the internal one.
 fn make_internal_rustflags(rustflags: &str) -> String {
     // Remove `-C tracer=<kind>`, as this would stifle optimisations.
-    let re = Regex::new(r"-C\s*tracer=[a-z]*").unwrap();
+    let re = regex::Regex::new(r"-C\s*tracer=[a-z]*").unwrap();
     re.replace_all(rustflags, "").to_string()
 }

--- a/build_aux.rs
+++ b/build_aux.rs
@@ -30,7 +30,9 @@ fn find_tracing_kind(rustflags: &str) -> String {
 
 /// Given the RUSTFLAGS for the external workspace, make flags for the internal one.
 fn make_internal_rustflags(rustflags: &str) -> String {
-    // Remove `-C tracer=<kind>`, as this would stifle optimisations.
-    let re = regex::Regex::new(r"-C\s*tracer=[a-z]*").unwrap();
+    // Remove `-C tracer=<kind>` and `-C llvm-args=tracer=<kind>` for ykrustc and cg_clif
+    // respectively, as this would stifle optimisations and in case of software tracing would cause
+    // the tracing callback to recursively call into itself.
+    let re = regex::Regex::new(r"-C\s*tracer=[a-z]*|-C\s*llvm-args=tracer=[a-z]*").unwrap();
     re.replace_all(rustflags, "").to_string()
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,6 @@
 //! For more information, see this section in the documentation:
 //! https://softdevteam.github.io/ykdocs/tech/yk_structure.html
 
-use regex::Regex;
 use std::{
     env,
     path::PathBuf,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,17 +39,37 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
         run_action(Workspace::Internal, target, extra_args);
     }
 
-    let mut tool = env::var("CARGO").unwrap();
-    let mut target_args = vec![target.to_string()];
-    let mut tool_args: Vec<&str> = Vec::new();
+    let mut cmd = if target == "fmt" {
+        // There is currently a bug where `cargo fmt` doesn't work for linked toolchains:
+        // https://github.com/rust-lang/rust/issues/81431
+        //
+        // As a workaround we fall back on the nightly toolchain installed via rustup. This
+        // is confusing. Normally when we run `cargo`, having used `rustup` to install, it
+        // is not actually `cargo` that we run, but a wrapper provided by `rustup`. It is
+        // this wrapper which understands the `+nightly` argument. The binary pointed to by
+        // by $CARGO (in the environment) is a real cargo (not a wrapper) which won't
+        // understand `+nightly`. So the easiest way to run `cargo fmt` for the nightly
+        // toolchain is to use `rustup run nightly cargo fmt`.
+        let mut cmd = Command::new("rustup");
+        cmd.args(&["run", "nightly", "cargo", "fmt"]);
+        cmd
+    } else {
+        let mut cmd = Command::new(env::var("CARGO").unwrap());
+        cmd.arg(target);
+        cmd
+    };
+
     let mut rust_flags = env::var("RUSTFLAGS").unwrap_or_else(|_| String::new());
 
     match target {
-        "audit" => (),
+        "audit" => {}
+        "fmt" => {
+            rust_flags.clear();
+        }
         "clean" => {
             if workspace == Workspace::Internal {
                 // The internal workspace is optimized.
-                target_args.push("--release".to_string());
+                cmd.arg("--release".to_string());
             }
         }
         "build" | "check" | "test" => {
@@ -58,12 +78,12 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
                 rust_flags = make_internal_rustflags(&rust_flags);
 
                 // Optimise the internal workspace.
-                target_args.push("--release".to_string());
+                cmd.arg("--release");
                 // Set the tracermode cfg macro, but without changing anything relating to code
                 // generation. We can't use `-C tracer=hw` as this would turn off optimisations
                 // and emit SIR for stuff we will never trace.
-                target_args.push("--features".to_string());
-                target_args.push(format!("yktrace/trace_{}", tracing_kind));
+                cmd.arg("--features");
+                cmd.arg(format!("yktrace/trace_{}", tracing_kind));
 
                 // `cargo test` in the internal workspace won't build libykshim.so, so we have
                 // to force-build it to avoid linkage problems for the external workspace.
@@ -72,32 +92,14 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
                 }
             }
         }
-        "fmt" => {
-            // There is currently a bug where `cargo fmt` doesn't work for linked toolchains:
-            // https://github.com/rust-lang/rust/issues/81431
-            //
-            // As a workaround we fall back on the nightly toolchain installed via rustup. This
-            // is confusing. Normally when we run `cargo`, having used `rustup` to install, it
-            // is not actually `cargo` that we run, but a wrapper provided by `rustup`. It is
-            // this wrapper which understands the `+nightly` argument. The binary pointed to by
-            // by $CARGO (in the environment) is a real cargo (not a wrapper) which won't
-            // understand `+nightly`. So the easiest way to run `cargo fmt` for the nightly
-            // toolchain is to use `rustup run nightly cargo fmt`.
-            rust_flags.clear();
-            tool = "rustup".to_owned();
-            tool_args.extend(&["run", "nightly", "cargo"]);
-        }
         _ => bail(format!(
             "the build system does not support the {} target",
             target
         )),
     }
 
-    let mut cmd = Command::new(&tool);
     let status = cmd
         .current_dir(workspace.dir())
-        .args(tool_args)
-        .args(target_args)
         .args(extra_args)
         .env("RUSTFLAGS", rust_flags)
         .spawn()
@@ -106,9 +108,7 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
         .unwrap();
 
     if !status.success() {
-        let pb = PathBuf::from(tool);
-        let base = pb.iter().last().unwrap().to_str().unwrap();
-        bail(format!("{} failed with exit code {}", base, status));
+        bail(format!("{:?} failed with {}", cmd, status));
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,116 +33,82 @@ impl Workspace {
     }
 }
 
-/// A build step for one of the workspaces.
-#[derive(Debug)]
-struct WorkspaceAction<'a> {
-    /// The tool we will invoke. Usually cargo.
-    tool: String,
-    /// Arguments to the above tool.
-    tool_args: Vec<&'a str>,
-    /// The path the to the workspace we will work in.
-    workspace_dir: PathBuf,
-    /// Arguments appended after `tool_args`.
-    target_args: Vec<String>,
-    /// The RUSTFLAGS environment to use.
-    rust_flags: String,
-    /// Workspace actions to run first.
-    forced_deps: Vec<Self>,
-}
-
-impl<'a> WorkspaceAction<'a> {
-    fn new(workspace: Workspace, target: &'a str) -> Result<Self, String> {
-        let mut tool = env::var("CARGO").unwrap();
-        let mut forced_deps = Vec::new();
-        let mut target_args = vec![target.to_string()];
-        let mut tool_args = Vec::new();
-        let mut rust_flags = env::var("RUSTFLAGS").unwrap_or_else(|_| String::new());
-
-        match target {
-            "audit" => (),
-            "clean" => {
-                if workspace == Workspace::Internal {
-                    // The internal workspace is optimized.
-                    target_args.push("--release".to_string());
-                }
-            }
-            "build" | "check" | "test" => {
-                if workspace == Workspace::Internal {
-                    let tracing_kind = find_tracing_kind(&rust_flags);
-                    rust_flags = make_internal_rustflags(&rust_flags);
-
-                    // Optimise the internal workspace.
-                    target_args.push("--release".to_string());
-                    // Set the tracermode cfg macro, but without changing anything relating to code
-                    // generation. We can't use `-C tracer=hw` as this would turn off optimisations
-                    // and emit SIR for stuff we will never trace.
-                    target_args.push("--features".to_string());
-                    target_args.push(format!("yktrace/trace_{}", tracing_kind));
-
-                    // `cargo test` in the internal workspace won't build libykshim.so, so we have
-                    // to force-build it to avoid linkage problems for the external workspace.
-                    if target == "test" {
-                        forced_deps.push(WorkspaceAction::new(Workspace::Internal, "build")?);
-                    }
-                }
-            }
-            "fmt" => {
-                // There is currently a bug where `cargo fmt` doesn't work for linked toolchains:
-                // https://github.com/rust-lang/rust/issues/81431
-                //
-                // As a workaround we fall back on the nightly toolchain installed via rustup. This
-                // is confusing. Normally when we run `cargo`, having used `rustup` to install, it
-                // is not actually `cargo` that we run, but a wrapper provided by `rustup`. It is
-                // this wrapper which understands the `+nightly` argument. The binary pointed to by
-                // by $CARGO (in the environment) is a real cargo (not a wrapper) which won't
-                // understand `+nightly`. So the easiest way to run `cargo fmt` for the nightly
-                // toolchain is to use `rustup run nightly cargo fmt`.
-                rust_flags.clear();
-                tool = "rustup".to_owned();
-                tool_args.extend(&["run", "nightly", "cargo"]);
-            }
-            _ => {
-                return Err(format!(
-                    "the build system does not support the {} target",
-                    target
-                ))
-            }
-        }
-
-        Ok(Self {
-            tool,
-            workspace_dir: workspace.dir(),
-            tool_args,
-            target_args,
-            rust_flags,
-            forced_deps,
-        })
+fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
+    // The external workspace depends on libykshim.so produced by the internal workspace
+    if workspace == Workspace::External {
+        run_action(Workspace::Internal, target, extra_args);
     }
 
-    fn run(self, extra_args: &[String]) -> Result<(), String> {
-        // Run any dependencies first.
-        for dep in self.forced_deps {
-            dep.run(&[])?;
-        }
+    let mut tool = env::var("CARGO").unwrap();
+    let mut target_args = vec![target.to_string()];
+    let mut tool_args: Vec<&str> = Vec::new();
+    let mut rust_flags = env::var("RUSTFLAGS").unwrap_or_else(|_| String::new());
 
-        let mut cmd = Command::new(&self.tool);
-        let status = cmd
-            .current_dir(self.workspace_dir)
-            .args(self.tool_args)
-            .args(self.target_args)
-            .args(extra_args)
-            .env("RUSTFLAGS", self.rust_flags)
-            .spawn()
-            .unwrap()
-            .wait()
-            .unwrap();
-
-        if !status.success() {
-            let pb = PathBuf::from(self.tool);
-            let base = pb.iter().last().unwrap().to_str().unwrap();
-            return Err(format!("{} failed with exit code {}", base, status));
+    match target {
+        "audit" => (),
+        "clean" => {
+            if workspace == Workspace::Internal {
+                // The internal workspace is optimized.
+                target_args.push("--release".to_string());
+            }
         }
-        Ok(())
+        "build" | "check" | "test" => {
+            if workspace == Workspace::Internal {
+                let tracing_kind = find_tracing_kind(&rust_flags);
+                rust_flags = make_internal_rustflags(&rust_flags);
+
+                // Optimise the internal workspace.
+                target_args.push("--release".to_string());
+                // Set the tracermode cfg macro, but without changing anything relating to code
+                // generation. We can't use `-C tracer=hw` as this would turn off optimisations
+                // and emit SIR for stuff we will never trace.
+                target_args.push("--features".to_string());
+                target_args.push(format!("yktrace/trace_{}", tracing_kind));
+
+                // `cargo test` in the internal workspace won't build libykshim.so, so we have
+                // to force-build it to avoid linkage problems for the external workspace.
+                if target == "test" {
+                    run_action(Workspace::Internal, "build", extra_args);
+                }
+            }
+        }
+        "fmt" => {
+            // There is currently a bug where `cargo fmt` doesn't work for linked toolchains:
+            // https://github.com/rust-lang/rust/issues/81431
+            //
+            // As a workaround we fall back on the nightly toolchain installed via rustup. This
+            // is confusing. Normally when we run `cargo`, having used `rustup` to install, it
+            // is not actually `cargo` that we run, but a wrapper provided by `rustup`. It is
+            // this wrapper which understands the `+nightly` argument. The binary pointed to by
+            // by $CARGO (in the environment) is a real cargo (not a wrapper) which won't
+            // understand `+nightly`. So the easiest way to run `cargo fmt` for the nightly
+            // toolchain is to use `rustup run nightly cargo fmt`.
+            rust_flags.clear();
+            tool = "rustup".to_owned();
+            tool_args.extend(&["run", "nightly", "cargo"]);
+        }
+        _ => bail(format!(
+            "the build system does not support the {} target",
+            target
+        )),
+    }
+
+    let mut cmd = Command::new(&tool);
+    let status = cmd
+        .current_dir(workspace.dir())
+        .args(tool_args)
+        .args(target_args)
+        .args(extra_args)
+        .env("RUSTFLAGS", rust_flags)
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    if !status.success() {
+        let pb = PathBuf::from(tool);
+        let base = pb.iter().last().unwrap().to_str().unwrap();
+        bail(format!("{} failed with exit code {}", base, status));
     }
 }
 
@@ -157,11 +123,5 @@ fn main() {
     let target = args.next().unwrap();
     let extra_args = args.collect::<Vec<_>>();
 
-    let run_action = |ws: Workspace, target: &str, args: &[String]| {
-        let act = WorkspaceAction::new(ws, target).unwrap_or_else(|e| bail(e));
-        act.run(args).unwrap_or_else(|e| bail(e));
-    };
-
-    run_action(Workspace::Internal, &target, &extra_args);
     run_action(Workspace::External, &target, &extra_args);
 }

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -1,4 +1,3 @@
-use regex::Regex;
 use std::env;
 use std::os::unix::fs::symlink;
 use std::path::PathBuf;


### PR DESCRIPTION
Together with a patched cg_clif and registering the custom attributes, this makes testing using cg_clif possible with `YK_EXT_RUSTFLAGS='--cfg tracermode="sw" -Clink-arg=-Wl,--export-dynamic -Cllvm-args=tracer=sw' ../rustc_codegen_cranelift/build/cargo.sh xtask test -p tests`.

Based on #231