### PR TITLE
Pass down rustflags

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -8,14 +8,20 @@ case ${CI_TRACER_KIND} in
        exit 1;;
 esac
 
-RUSTFLAGS="${RUSTFLAGS} -D warnings"
+export RUSTFLAGS="-C tracer=${CI_TRACER_KIND} -D warnings"
 
 # Use the most recent successful ykrustc build.
 tar jxf /opt/ykrustc-bin-snapshots/ykrustc-${CI_TRACER_KIND}-stage2-latest.tar.bz2
 export PATH=`pwd`/ykrustc-stage2-latest/bin:${PATH}
 
-RUSTFLAGS="-C tracer=${CI_TRACER_KIND}" cargo xtask test
+# Test both workspaces.
+cargo xtask test
+cargo xtask clean
 
+# Also test the build without xtask, as that's what consumers will do.
+cargo build
+
+unset RUSTFLAGS
 export CARGO_HOME="`pwd`/.cargo"
 export RUSTUP_HOME="`pwd`/.rustup"
 export RUSTUP_INIT_SKIP_PATH_CHECK="yes"

--- a/build_aux.rs
+++ b/build_aux.rs
@@ -16,3 +16,15 @@ fn find_tracing_kind(rustflags: &str) -> String {
     }
     tracing_kind.to_owned()
 }
+
+/// Given the RUSTFLAGS for the external workspace, make flags for the internal one.
+fn make_internal_rustflags(rustflags: &str) -> String {
+    // Remove `-C tracer=<kind>`, as this would stifle optimisations.
+    let re = Regex::new(r"-C\s*tracer=[a-z]*").unwrap();
+    let mut int_rustflags = re.replace_all(rustflags, "").to_string();
+
+    // Set the tracermode cfg macro, but without changing anything relating to code generation.
+    let tracing_kind = find_tracing_kind(&rustflags);
+    int_rustflags.push_str(&format!(" --cfg tracermode=\"{}\"", tracing_kind));
+    int_rustflags
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,15 +59,11 @@ impl<'a> WorkspaceAction<'a> {
         match target {
             "audit" => (),
             "build" | "check" | "clean" | "test" => {
-                let tracing_kind = find_tracing_kind(&rust_flags);
                 if workspace == Workspace::Internal {
-                    rust_flags.clear();
+                    rust_flags = make_internal_rustflags(&rust_flags);
+
                     // Optimise the internal workspace.
                     target_args.push("--release");
-                    // Set the tracermode cfg macro, but without changing anything relating to code
-                    // generation. We can't use `-C tracer=hw` as this would turn off optimisations
-                    // and emit SIR for stuff we will never trace.
-                    rust_flags.push_str(&format!(" --cfg tracermode=\"{}\"", tracing_kind));
 
                     // `cargo test` in the internal workspace won't build libykshim.so, so we have
                     // to force-build it to avoid linkage problems for the external workspace.


### PR DESCRIPTION
Took a while to get this right, as the flags seem to be handled differently depending on if the toolchain is overridden in rustup or not.

This seems to work for our common scenarios (for developers and CI).

This means we now catch warnings in the internal workspace during CI.