### PR TITLE
Use Arc<Body> instead of allocating strings.

### DIFF
--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -298,11 +298,8 @@ pub extern "sysv64" fn bh_push_vec(
 ) {
     let fname =
         unsafe { std::str::from_utf8(std::slice::from_raw_parts(sym_ptr, sym_len)).unwrap() };
-    let fi = FrameInfo {
-        sym: fname.to_string(),
-        bbidx,
-        mem,
-    };
+    let body = SIR.body(fname).unwrap();
+    let fi = FrameInfo { body, bbidx, mem };
     let mut v = unsafe { Box::from_raw(vptr) };
     v.push(fi);
     Box::into_raw(v);


### PR DESCRIPTION
Instead of cloning the strings we get from the compiler, reference the body directly, which is in an Arc and thus only costs a pointer.