### PR TITLE
Fix recursion in `do_not_trace` functions.

### DIFF
--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -93,7 +93,7 @@ impl Location {
             Location::Reg(..) => {
                 assert!(off == 0);
                 self
-            },
+            }
             Location::Const { .. } => todo!("offsetting a constant"),
         }
     }


### PR DESCRIPTION
Until now there was a bug which prevented us from properly converting
traces to TIR that contained recursive functions that are annotated with
`do_not_trace`. In order to detect when we are done ignoring the content
of such a function, we waited until we observed its return terminator.
However, due to recursion, the return terminator we see might not belong
to the outer-most function, thus aborting the ignore path too early.
This commit fixes this, by counting how often we enter the recursive
function, and only stop ignoring things when we see the outer-most
return.