### PR TITLE
Remove sg_interpret.

### DIFF
--- a/internal_ws/ykcompile/src/lib.rs
+++ b/internal_ws/ykcompile/src/lib.rs
@@ -139,7 +139,10 @@ pub struct CompiledTrace {
 }
 
 impl CompiledTrace {
-    /// Execute the trace by calling (not jumping to) the first instruction's address.
+    /// Execute the trace by calling (not jumping to) the first instruction's address. Returns a
+    /// pointer to an initialised `StopgapInterpreter` if there was a guard failure, or a null
+    /// pointer otherwise. Note that the interpreter holds a `*mut` pointer to `args`, so we need
+    /// to make sure that `args` is still alive when we call the interpreters `interpret` function.
     pub unsafe fn execute<TT>(&self, args: &mut TT) -> *mut StopgapInterpreter {
         let func: extern "sysv64" fn(&mut TT) -> *mut StopgapInterpreter =
             mem::transmute(self.mc.ptr(dynasmrt::AssemblyOffset(0)));

--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -235,21 +235,15 @@ impl StopgapInterpreter {
             };
             frames.push(frame);
         }
-        StopgapInterpreter { frames }
-    }
-
-    /// Run the SIR interpreter after it has been initialised by a guard failure. Since we start in
-    /// the block where the guard failed, we immediately skip to the terminator and interpret it to
-    /// see which block we need to start interpretation in.
-    pub unsafe fn sg_interpret(&mut self, ctx: *mut u8) {
-        self.set_interp_ctx(ctx);
-        // Jump to the correct basic block by interpreting the terminator.
-        let frame = self.frames.last().unwrap();
+        let mut sg = StopgapInterpreter { frames };
+        let frame = sg.frames.last().unwrap();
+        // Since we start in the block where the guard failed, we immediately skip to the
+        // terminator and interpret it to initialise the block where actual interpretation needs to
+        // start.
         let body = frame.body.clone();
         let bbidx = usize::try_from(frame.bbidx).unwrap();
-        self.terminator(&body.blocks[bbidx].term);
-        // Start interpretation.
-        self.interpret();
+        sg.terminator(&body.blocks[bbidx].term);
+        sg
     }
 
     /// Given the symbol name of a function, generate a `StackFrame` which allocates the precise

--- a/internal_ws/ykshim/src/lib.rs
+++ b/internal_ws/ykshim/src/lib.rs
@@ -105,9 +105,9 @@ unsafe fn __ykshim_tirtrace_drop(tir_trace: *mut TirTrace) {
 
 /// Start an initialised StopgapInterpreter.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_si_interpret(si: *mut yksg::StopgapInterpreter, ctx: *mut u8) {
+unsafe extern "C" fn __ykshim_si_interpret(si: *mut yksg::StopgapInterpreter) {
     let si = &mut *si;
-    si.sg_interpret(ctx);
+    si.interpret();
 }
 
 #[no_mangle]

--- a/internal_ws/yktrace/src/tir.rs
+++ b/internal_ws/yktrace/src/tir.rs
@@ -5,7 +5,7 @@
 use super::SirTrace;
 use crate::{
     errors::InvalidTraceError,
-    sir::{self, Sir}
+    sir::{self, Sir, INTERP_STEP_ARG}
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -227,6 +227,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                             in_interp_step = true;
                             entered_call = true;
                             live_locals.push(HashSet::new());
+                            live_locals.last_mut().unwrap().insert(INTERP_STEP_ARG);
                             continue;
                         }
                     }

--- a/tests/src/stopgap/guard_fail.rs
+++ b/tests/src/stopgap/guard_fail.rs
@@ -37,7 +37,7 @@ fn simple() {
     assert!(!ptr.is_null());
     // Check that running the interpreter gets us the correct result.
     let mut si: StopgapInterpreter = StopgapInterpreter(ptr);
-    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    unsafe { si.interpret() };
     assert_eq!(args.1, 10);
 }
 
@@ -82,7 +82,7 @@ fn recursion() {
     assert!(!ptr.is_null());
     // Check that running the interpreter gets us the correct result.
     let mut si: StopgapInterpreter = StopgapInterpreter(ptr);
-    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    unsafe { si.interpret() };
     assert_eq!(args.1, 99);
 }
 
@@ -122,6 +122,6 @@ fn recursion2() {
     assert!(!ptr.is_null());
     // Check that running the interpreter gets us the correct result.
     let mut si: StopgapInterpreter = StopgapInterpreter(ptr);
-    unsafe { si.interpret(&mut args as *mut _ as *mut u8) };
+    unsafe { si.interpret() };
     assert_eq!(args.1, 5);
 }

--- a/ykrt/src/mt.rs
+++ b/ykrt/src/mt.rs
@@ -196,7 +196,7 @@ impl MTThread {
                 } else {
                     unsafe {
                         let mut si = StopgapInterpreter(ptr);
-                        si.interpret(ctx as *mut _ as *mut u8);
+                        si.interpret();
                     }
                 }
             }

--- a/ykshim_client/src/lib.rs
+++ b/ykshim_client/src/lib.rs
@@ -48,7 +48,7 @@ extern "C" {
     fn __ykshim_compiled_trace_get_ptr(compiled_trace: *const RawCompiledTrace) -> *const c_void;
     fn __ykshim_compiled_trace_drop(compiled_trace: *mut RawCompiledTrace);
     fn __ykshim_sirtrace_drop(trace: *mut RawSirTrace);
-    fn __ykshim_si_interpret(interp: *mut RawStopgapInterpreter, ctx: *mut u8);
+    fn __ykshim_si_interpret(interp: *mut RawStopgapInterpreter);
     fn __ykshim_sirinterpreter_drop(interp: *mut RawStopgapInterpreter);
 }
 
@@ -96,8 +96,8 @@ impl Drop for ThreadTracer {
 pub struct StopgapInterpreter(pub *mut RawStopgapInterpreter);
 
 impl StopgapInterpreter {
-    pub unsafe fn interpret(&mut self, ctx: *mut u8) {
-        __ykshim_si_interpret(self.0, ctx);
+    pub unsafe fn interpret(&mut self) {
+        __ykshim_si_interpret(self.0);
     }
 }
 


### PR DESCRIPTION
This function was needed to properly initialise the stopgap interpreter
when coming from a guard failure. By adding the local holding the
interpreter context to the live locals, the function can be moved into
`from_frames`, which means `sg_interpret` is no longer needed.

There is one thing that makes me a nervous about this, which is why I'm leaving this as a draft for now. Since we store a reference to the interpreter context inside the stopgap interpreter before calling `interpret`, there is a way to get UB here:
```rust
let mut args = InterpCtx(0);
let ptr = ct.execute(&mut args);
let mut si = StopgapInterpreter(ptr);
args = InterpCtx(1); // if we overwrite args here, then si's frame still points to the previous InterpCtx.
si.interpret();
assert_eq!(args.0, 9);
```
At the very least we need to document this, but I'm hoping we can give a stronger guarantee (without having to pass args into `interpret` like before).