### PR TITLE
Rethink the Location state machine.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
+parking_lot = "0.11"
+parking_lot_core = "0.8"
+strum = { version = "0.20", features = ["derive"] }
 ykshim_client = { path = "../ykshim_client" }
 
 [build-dependencies]


### PR DESCRIPTION
Previously we tried to do everything locklessly. This is not only very complicated, but it's very difficult to be sure  that it's correct. There is at least one potential flaw in the existing code, and maybe more that I haven't realised yet.

This commit moves us to a very different scheme, which is probably best described by copying and pasting this comment from the code:

```
A Location is a state machine which operates as follows (where Counting is the
start state):

             ┌──────────────┐
             │              │─────────────┐
  reprofile  │   Counting   │             │
 ┌──────────▶│              │◀────────────┘
 │           └──────────────┘    increment
 │             │                 count
 │             │ start tracing
 │             ▼
 │           ┌──────────────┐
 |           |              | incomplete  ┌─────────────┐
 │           │   Tracing    │────────────▶|  DontTrace  |
 |           |              |             └─────────────┘
 │           └──────────────┘
 │             │ start compiling trace
 │             │ in thread
 │             ▼
 │           ┌──────────────┐
 |           |  Compiling   |
 │           └──────────────┘
 │             │
 │             │ trace compiled
 │             ▼
 │           ┌──────────────┐
 └───────────│   Compiled   |
             └──────────────┘

We hope that a Location soon reaches the Compiled state (aka "the happy state")
and stays there.

The state machine is encoded in a usize in a not-entirely-simple way, as we
don't want to allocate any memory for Locations that do not become hot. The
layout is as follows (on a 64 bit machine):

  bit(s) | 63..3   | 2           | 1         | 0
         | payload | IS_COUNTING | IS_PARKED | IS_LOCKED

In the Counting state, IS_COUNTING is set to 1, and the parking lot mutex bits
are unused and must remain set at 0. The payload representing the count is
incremented locklessly. All other states have IS_COUNTING set to 0 and the
payload is the address of a boxed HotLocation, access to which is controlled by
the two parking lot mutex bits.

The possible combinations of the counting and mutex bits are thus as follows:

  payload       | IS_COUNTING | IS_PARKED | IS_LOCKED | Notes
  --------------+-----------+---------+---------+-----------------------------------
  <count>       | 1           | 0         | 0         | Start state
                | 1           | 0         | 1         | Illegal state
                | 1           | 1         | 0         | Illegal state
                | 1           | 1         | 1         | Illegal state
  <HotLocation> | 0           | 0         | 0         | Not locked, no-one waiting
  <HotLocation> | 0           | 0         | 1         | Locked, no thread(s) waiting
  <HotLocation> | 0           | 1         | 0         | Not locked, thread(s) waiting
  <HotLocation> | 0           | 1         | 1         | Locked, thread(s) waiting

where `<count>` is an integer and `<HotLocation>` is a boxed `HotLocation` enum.

The precise semantics of locking and, in particular, parking are subtle:
interested readers are directed to
https://github.com/Amanieu/parking_lot/blob/master/src/raw_mutex.rs#L33 for a
more precise definition.
```

The parking lot code looks more complicated than it really is: in essence, the approach outlined in
https://github.com/Amanieu/parking_lot/blob/master/src/raw_mutex.rs for `lock` and `unlock` needs only minor adapting to our situation.

Significantly, using parking lot means that we no longer spin incompetently: threads can actually sleep. Intriguingly, our test suite now takes longer to run (on b13 ~3.2s vs. 2.0s before) *but* it consumes less CPU in doing so (user time 14.6s vs. 15.5s before), so it is in some senses "more efficient". Because we now use a mutex much more often, we are unlikely to get back to the performance we had before, but nor do we really need to: the test suite exercises the worst case of performance especially because we do not currently loop in the compiled machine code. Still, it would be nice to reduce some of the unnecessary double loads that we have here.

I believe/hope this code is correct (or, at least, it's less flawed than what we had before), but it is not as well organised as I would like, nor is it as fast as I would like. However, I think that it wouldn't be sensible for me to polish this endlessly in my private tree: it's better to get this in on the basis that it's a correctness fix, and then we can deal with "niceness" and "speed" in-tree.