### PR TITLE
Correctly handle `cargo xtask fmt` args.

### DIFF
--- a/internal_ws/ykcompile/src/arch/x86_64/mod.rs
+++ b/internal_ws/ykcompile/src/arch/x86_64/mod.rs
@@ -636,7 +636,14 @@ impl TraceCompiler {
         dest_loc
     }
 
-    fn c_binop(&mut self, dest: &IRPlace, op: BinOp, opnd1: &IRPlace, opnd2: &IRPlace, checked: bool) {
+    fn c_binop(
+        &mut self,
+        dest: &IRPlace,
+        op: BinOp,
+        opnd1: &IRPlace,
+        opnd2: &IRPlace,
+        checked: bool,
+    ) {
         let opnd1_ty = SIR.ty(&opnd1.ty());
         debug_assert!(opnd1_ty == SIR.ty(&opnd2.ty()));
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,7 +23,7 @@ enum Workspace {
 fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
     // The external workspace depends on libykshim.so produced by the internal workspace
     if workspace == Workspace::External {
-        run_action(Workspace::Internal, target, &[]);
+        run_action(Workspace::Internal, target, extra_args);
     }
 
     let mut cmd = if ["fmt", "clippy"].contains(&target) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -89,8 +89,7 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
                 let tracing_kind = find_tracing_kind(&rust_flags);
                 rust_flags = make_internal_rustflags(&rust_flags);
 
-                // Optimise the internal workspace. Don't pass `--release` for `cargo bench`
-                // however as it is already implied (and explicitly passing it is illegal).
+                // Optimise the internal workspace. `--release` is not valid for `cargo bench`.
                 if target != "bench" {
                     cmd.arg("--release");
                 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -89,8 +89,8 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String]) {
                 let tracing_kind = find_tracing_kind(&rust_flags);
                 rust_flags = make_internal_rustflags(&rust_flags);
 
-                // Optimise the internal workspace. Don't pass `--release` for `cargo bench` however as it is
-                // already implied (and explicitly passing it is illegal).
+                // Optimise the internal workspace. Don't pass `--release` for `cargo bench`
+                // however as it is already implied (and explicitly passing it is illegal).
                 if target != "bench" {
                     cmd.arg("--release");
                 }


### PR DESCRIPTION
We just need to pass down extra args to the internal workspace.

[I also learned that by default `rustfmt` will not wrap long comments]