### PR TITLE
Start tweaking the unsafe code

### DIFF
--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -44,51 +44,35 @@ impl Drop for LocalMem {
 }
 
 impl LocalMem {
-    /// Given a pointer `src` and a size, write its value to the pointer `dst`.
-    pub fn write_val(&mut self, dst: *mut u8, src: *const u8, size: usize) {
-        unsafe {
-            std::ptr::copy(src, dst, size);
-        }
-    }
-
     /// Write a constant to the pointer `dst`.
-    fn write_const(&mut self, dst: *mut u8, constant: &Constant) {
+    unsafe fn write_const(&mut self, dst: *mut u8, constant: &Constant) {
         match constant {
             Constant::Int(ci) => match ci {
                 ConstantInt::UnsignedInt(ui) => match ui {
-                    UnsignedInt::U8(v) => self.write_val(dest, [*v].as_ptr(), 1),
-                    UnsignedInt::Usize(v) => {
-                        let bytes = v.to_ne_bytes();
-                        self.write_val(dest, bytes.as_ptr(), bytes.len())
-                    }
+                    UnsignedInt::U8(v) => std::ptr::copy(v, dst, 1),
+                    UnsignedInt::Usize(v) => std::ptr::copy(v, dst as *mut usize, 1),
                     _ => todo!(),
                 },
                 ConstantInt::SignedInt(_) => todo!(),
             },
-            Constant::Bool(b) => self.write_val(dest, [*b as u8].as_ptr(), 1),
-            Constant::Tuple(t) => {
-                if SIR.ty(t).size() == 0 {
-                    // ZST: do nothing.
-                } else {
-                    todo!()
-                }
-            }
+            Constant::Bool(b) => std::ptr::copy(b as *const bool, dst as *mut bool, 1),
+            Constant::Tuple(t) if SIR.ty(t).size() == 0 => (), // ZST: do nothing
             _ => todo!(),
         }
     }
 
     /// Stores one IRPlace into another.
-    fn store(&mut self, dest: &IRPlace, src: &IRPlace) {
+    fn store(&mut self, dst: &IRPlace, src: &IRPlace) {
         match src {
             IRPlace::Val { .. } | IRPlace::Indirect { .. } => {
                 let src_ptr = self.iplace_to_ptr(src);
-                let dst_ptr = self.iplace_to_ptr(dest);
+                let dst_ptr = self.iplace_to_ptr(dst);
                 let size = usize::try_from(SIR.ty(&src.ty()).size()).unwrap();
-                self.write_val(dst_ptr, src_ptr, size);
+                unsafe { std::ptr::copy(src_ptr, dst_ptr, size); }
             }
             IRPlace::Const { val, ty: _ty } => {
-                let dst_ptr = self.iplace_to_ptr(dest);
-                self.write_const(dst_ptr, val);
+                let dst_ptr = self.iplace_to_ptr(dst);
+                unsafe { self.write_const(dst_ptr, val); }
             }
             _ => todo!(),
         }
@@ -102,10 +86,10 @@ impl LocalMem {
                 IRPlace::Val { .. } | IRPlace::Indirect { .. } => {
                     let src = frame.iplace_to_ptr(arg);
                     let size = usize::try_from(SIR.ty(&arg.ty()).size()).unwrap();
-                    self.write_val(dst, src, size);
+                    unsafe { std::ptr::copy(src, dst, size); }
                 }
                 IRPlace::Const { val, .. } => {
-                    self.write_const(dst, val);
+                    unsafe { self.write_const(dst, val); }
                 }
                 _ => unreachable!(),
             }
@@ -178,7 +162,9 @@ macro_rules! make_binop {
                 todo!("Raise error.")
             }
             let bytes = v.to_ne_bytes();
-            locals.write_val(ptr, bytes.as_ptr(), bytes.len());
+            unsafe {
+                std::ptr::copy(bytes.as_ptr(), ptr, bytes.len());
+            }
         }
     };
 }
@@ -274,12 +260,10 @@ impl StopgapInterpreter {
     }
 
     /// Inserts a pointer to the interpreter context into the `interp_step` frame.
-    pub fn set_interp_ctx(&mut self, ctx: *mut u8) {
+    pub unsafe fn set_interp_ctx(&mut self, ctx: *mut u8) {
         // The interpreter context lives in $1
         let ptr = self.frames.first().unwrap().mem.local_ptr(&INTERP_STEP_ARG);
-        unsafe {
-            std::ptr::write::<*mut u8>(ptr as *mut *mut u8, ctx);
-        }
+        std::ptr::write::<*mut u8>(ptr as *mut *mut u8, ctx);
     }
 
     pub unsafe fn interpret(&mut self) {
@@ -349,7 +333,7 @@ impl StopgapInterpreter {
                     // Write the return value to the destination in the previous frame.
                     let dst_ptr = curframe.mem.iplace_to_ptr(&dest);
                     let size = usize::try_from(SIR.ty(&dest.ty()).size()).unwrap();
-                    curframe.mem.write_val(dst_ptr, ret_ptr, size);
+                    unsafe { std::ptr::copy(ret_ptr, dst_ptr, size); }
                     curframe.bbidx = bbidx;
                 }
             }

--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -52,7 +52,7 @@ impl LocalMem {
     }
 
     /// Write a constant to the pointer `dst`.
-    pub fn write_const(&mut self, dest: *mut u8, constant: &Constant) {
+    fn write_const(&mut self, dst: *mut u8, constant: &Constant) {
         match constant {
             Constant::Int(ci) => match ci {
                 ConstantInt::UnsignedInt(ui) => match ui {
@@ -95,7 +95,7 @@ impl LocalMem {
     }
 
     /// Copy over the call arguments from another frame.
-    pub fn copy_args(&mut self, args: &[IRPlace], frame: &LocalMem) {
+    fn copy_args(&mut self, args: &[IRPlace], frame: &LocalMem) {
         for (i, arg) in args.iter().enumerate() {
             let dst = self.local_ptr(&Local(u32::try_from(i + 1).unwrap()));
             match arg {


### PR DESCRIPTION
This PR is a very lightweight pass over the stopgap interpreter's unsafe code. It marks a few more functions as `unsafe` (https://github.com/softdevteam/yk/commit/aa05f0503cec32c002ea07cce111081f97c768a0), reduces the visibility of unsafe code (https://github.com/softdevteam/yk/commit/72f039ad05024a8f3eb24a09ea76639cfb706740), and simplifies various code doing unsafe things (https://github.com/softdevteam/yk/commit/72f039ad05024a8f3eb24a09ea76639cfb706740). I also couldn't help myself noticing that we were wildly inconsistent in spelling `dst` and `dest`: the former makes more sense with `src`, so I did a `srep` renaming with that (https://github.com/softdevteam/yk/commit/4bca1ea7eb474f4b973ce18ec8f2726adadca983).

In one sense this PR doesn't do very much that's hugely useful: it doesn't properly document safety constraints, for example. That's because I haven't really got my head around some of that yet. But, since this seems a fairly safe (pun intended) small step, I thought I might as well raise this now, rather than storing it up for a later monster PR.