### PR TITLE
More thoroughly test binary operations.

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 fm = "0.2.0"
 ykshim_client = { path = "../ykshim_client" }
 libc = "0.2.82"
+paste = "1.0"
 regex = "1.4.3"
 ykrt = { path = "../ykrt" }
 

--- a/tests/src/codegen/mod.rs
+++ b/tests/src/codegen/mod.rs
@@ -3,6 +3,7 @@
 use crate::helpers::{add6, add_some};
 use libc;
 use libc::{abs, getuid};
+use paste::paste;
 use ykshim_client::{compile_tir_trace, compile_trace, start_tracing, TirTrace, TracingKind};
 
 mod reg_alloc;
@@ -233,28 +234,113 @@ fn ext_call_and_spilling() {
     assert_eq!(ctx.0, args.0);
 }
 
-#[test]
-fn binop_add_simple() {
-    #[derive(Eq, PartialEq, Debug)]
-    struct InterpCtx(u64, u64, u64);
+/// Generates a test for a binary operation.
+macro_rules! mk_binop_test {
+    ($name: ident, $op: tt, $type: ident, $arg1: expr, $arg2: expr, $expect: expr) => {
+        paste! {
+            #[test]
+            fn [<$name _ $type>]() {
+                #[derive(Eq, PartialEq, Debug)]
+                struct BinopCtx {
+                    arg1: $type,
+                    arg2: $type,
+                    res: $type,
+                }
 
-    #[interp_step]
-    fn interp_stepx(io: &mut InterpCtx) {
-        io.2 = io.0 + io.1 + 3;
-    }
+                impl BinopCtx {
+                    fn new(arg1: $type, arg2: $type, res: $type) -> Self {
+                        Self { arg1, arg2, res }
+                    }
+                }
 
-    let mut ctx = InterpCtx(5, 2, 0);
-    #[cfg(tracermode = "hw")]
-    let th = start_tracing(TracingKind::HardwareTracing);
-    #[cfg(tracermode = "sw")]
-    let th = start_tracing(TracingKind::SoftwareTracing);
-    interp_stepx(&mut ctx);
-    let sir_trace = th.stop_tracing().unwrap();
-    let ct = compile_trace(sir_trace).unwrap();
-    let mut args = InterpCtx(5, 2, 0);
-    assert!(unsafe { ct.execute(&mut args).is_null() });
-    assert_eq!(args, InterpCtx(5, 2, 10));
+                #[interp_step]
+                fn interp_step(ctx: &mut BinopCtx) {
+                    ctx.res = ctx.arg1 $op ctx.arg2;
+                }
+
+                let mut ctx = BinopCtx::new($arg1, $arg2, 0);
+                #[cfg(tracermode = "hw")]
+                let th = start_tracing(TracingKind::HardwareTracing);
+                #[cfg(tracermode = "sw")]
+                let th = start_tracing(TracingKind::SoftwareTracing);
+                interp_step(&mut ctx);
+                let sir_trace = th.stop_tracing().unwrap();
+                let ct = compile_trace(sir_trace).unwrap();
+
+                let mut args = BinopCtx::new($arg1, $arg2, 0);
+                assert!(unsafe { ct.execute(&mut args).is_null() });
+                assert_eq!(args, BinopCtx::new($arg1, $arg2, $expect));
+            }
+        }
+    };
 }
+
+/// Generates binary operation tests for all unsigned types.
+/// Since all types are tested, numeric operands must fit in a u8.
+macro_rules! mk_binop_tests_unsigned {
+    ($name: ident, $op: tt, $arg1: expr, $arg2: expr, $expect: expr) => {
+        mk_binop_test!($name, $op, u8, $arg1, $arg2, $expect);
+        mk_binop_test!($name, $op, u16, $arg1, $arg2, $expect);
+        mk_binop_test!($name, $op, u32, $arg1, $arg2, $expect);
+        mk_binop_test!($name, $op, u64, $arg1, $arg2, $expect);
+        // FIXME u128 hits unreachable code.
+    };
+}
+
+/// Generates binary operation tests for all signed types.
+/// Since all types are tested, numeric operands must fit in an i8.
+macro_rules! mk_binop_tests_signed {
+    ($name: ident, $op: tt, $arg1: expr, $arg2: expr, $expect: expr) => {
+        mk_binop_test!($name, $op, i8, $arg1, $arg2, $expect);
+        mk_binop_test!($name, $op, i16, $arg1, $arg2, $expect);
+        mk_binop_test!($name, $op, i32, $arg1, $arg2, $expect);
+        mk_binop_test!($name, $op, i64, $arg1, $arg2, $expect);
+        // FIXME i128 hits unreachable code.
+    };
+}
+
+mk_binop_tests_unsigned!(binop_add1, +, 0, 0, 0);
+mk_binop_tests_signed!(binop_add2, +, 0, 0, 0);
+mk_binop_tests_unsigned!(binop_add3, +, 1, 1, 2);
+mk_binop_tests_signed!(binop_add4, +, 1, 1, 2);
+mk_binop_tests_unsigned!(binop_add5, +, 253, 2, 255);
+mk_binop_tests_signed!(binop_add6, +, 125, 2, 127);
+mk_binop_test!(binop_add7, +, u16, u16::MAX - 7, 7, u16::MAX);
+mk_binop_test!(binop_add8, +, u32, u32::MAX - 14, 14, u32::MAX);
+mk_binop_test!(binop_add9, +, u64, u64::MAX - 100, 100, u64::MAX);
+mk_binop_test!(binop_add10, +, i16, i16::MAX - 7, 7, i16::MAX);
+mk_binop_test!(binop_add11, +, i32, i32::MAX - 14, 14, i32::MAX);
+mk_binop_test!(binop_add13, +, i64, i64::MAX - 100, 100, i64::MAX);
+
+mk_binop_tests_unsigned!(binop_sub1, -, 0, 0, 0);
+mk_binop_tests_signed!(binop_sub2, -, 0, 0, 0);
+mk_binop_tests_unsigned!(binop_sub3, -, 1, 0, 1);
+mk_binop_tests_signed!(binop_sub4, -, 1, 0, 1);
+mk_binop_tests_signed!(binop_sub5, -, 0, 1, -1);
+mk_binop_tests_signed!(binop_sub6, -, -120, 8, -128);
+mk_binop_tests_signed!(binop_sub7, -, -1, -1, 0);
+mk_binop_test!(binop_sub8, -, u16, u16::MAX, 7, u16::MAX - 7);
+mk_binop_test!(binop_sub9, -, u32, u32::MAX, 8, u32::MAX - 8);
+mk_binop_test!(binop_sub10, -, u64, u64::MAX, 33, u64::MAX - 33);
+mk_binop_test!(binop_sub11, -, i16, i16::MAX, 7, i16::MAX - 7);
+mk_binop_test!(binop_sub12, -, i32, i32::MAX, 8, i32::MAX - 8);
+mk_binop_test!(binop_sub13, -, i64, i64::MAX, 33, i64::MAX - 33);
+
+// FIXME implement and test signed multiplication.
+mk_binop_tests_unsigned!(binop_mul1, *, 0, 0, 0);
+mk_binop_tests_unsigned!(binop_mul2, *, 10, 10, 100);
+mk_binop_tests_unsigned!(binop_mul3, *, 15, 15, 225);
+mk_binop_test!(binop_mul4, *, u16, 510, 8, 4080);
+mk_binop_test!(binop_mul5, *, u32, 131072, 8, 1048576);
+mk_binop_test!(binop_mul5, *, u64, 8589934592u64, 8, 68719476736);
+
+// FIXME implement and test signed division.
+mk_binop_tests_unsigned!(binop_div1, /, 1, 1, 1);
+mk_binop_tests_unsigned!(binop_div2, /, 2, 1, 2);
+mk_binop_tests_unsigned!(binop_div3, /, 252, 4, 63);
+mk_binop_test!(binop_div4, /, u16, 4080, 8, 510);
+mk_binop_test!(binop_div5, /, u32, 1048576, 8, 131072);
+mk_binop_test!(binop_div6, /, u64, 68719476736u64, 8, 8589934592);
 
 #[test]
 fn binop_add_overflow() {
@@ -308,6 +394,104 @@ fn binop_other() {
     let mut args = InterpCtx(5, 2, 0);
     assert!(unsafe { ct.execute(&mut args).is_null() });
     assert_eq!(args, InterpCtx(5, 5, 10));
+}
+
+/// Binary operations where a lot of registers are in use.
+/// Designed to test if we've correctly handled clobbering of x86_64 MUL and DIV.
+#[test]
+fn binop_many_locals() {
+    #[derive(Eq, PartialEq, Debug, Clone)]
+    struct InterpCtx {
+        input: u64,
+        mul_res: u64,
+        div_res: u64,
+        x1: u64,
+        x2: u64,
+        x3: u64,
+        x4: u64,
+        x5: u64,
+        x6: u64,
+        x7: u64,
+        x8: u64,
+        x9: u64,
+        x10: u64,
+    }
+
+    #[interp_step]
+    fn interp_step(ctx: &mut InterpCtx) {
+        // Make a lot of locals to fill many registers.
+        let x1 = ctx.input + 1;
+        let x2 = ctx.input + 2;
+        let x3 = ctx.input + 3;
+        let x4 = ctx.input + 4;
+        let x5 = ctx.input + 5;
+        let x6 = ctx.input + 6;
+        let x7 = ctx.input + 7;
+        let x8 = ctx.input + 8;
+        let x9 = ctx.input + 9;
+        let x10 = ctx.input + 10;
+
+        // Perform some multiplication and division.
+        ctx.mul_res = ctx.input * 5;
+        ctx.div_res = ctx.input / 4;
+
+        // These should not have been clobbered.
+        ctx.x1 = x1;
+        ctx.x2 = x2;
+        ctx.x3 = x3;
+        ctx.x4 = x4;
+        ctx.x5 = x5;
+        ctx.x6 = x6;
+        ctx.x7 = x7;
+        ctx.x8 = x8;
+        ctx.x9 = x9;
+        ctx.x10 = x10;
+    }
+
+    let ctx = InterpCtx {
+        input: 0,
+        mul_res: 0,
+        div_res: 0,
+        x1: 0,
+        x2: 0,
+        x3: 0,
+        x4: 0,
+        x5: 0,
+        x6: 0,
+        x7: 0,
+        x8: 0,
+        x9: 0,
+        x10: 0,
+    };
+    let expect = InterpCtx {
+        input: 0,
+        mul_res: 0,
+        div_res: 0,
+        x1: 1,
+        x2: 2,
+        x3: 3,
+        x4: 4,
+        x5: 5,
+        x6: 6,
+        x7: 7,
+        x8: 8,
+        x9: 9,
+        x10: 10,
+    };
+
+    let mut ctx1 = ctx.clone();
+    #[cfg(tracermode = "hw")]
+    let th = start_tracing(TracingKind::HardwareTracing);
+    #[cfg(tracermode = "sw")]
+    let th = start_tracing(TracingKind::SoftwareTracing);
+    interp_step(&mut ctx1);
+    let sir_trace = th.stop_tracing().unwrap();
+    assert_eq!(ctx1, expect);
+
+    let ct = compile_trace(sir_trace).unwrap();
+    let mut ctx2 = ctx.clone();
+    assert!(unsafe { ct.execute(&mut ctx2).is_null() });
+    assert_eq!(ctx2, expect);
 }
 
 #[test]


### PR DESCRIPTION
This will probably be tricky to review. It's all details.

In the end I opted *not* to split the codegen for MUL and DIV. Although they have different semantics, under the subset of conditions that we use these instructions, they are in fact very similar. I've added a big comment attempting to explain this.

We use macros to help us generate a lot of tests.

Several nasty bugs found and fixed along the way.