### PR TITLE
Add a 'testing' feature.

### DIFF
--- a/internal_ws/yksg/Cargo.toml
+++ b/internal_ws/yksg/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 libc = "0.2.82"
 yktrace = { path = "../yktrace" }
 ykpack = { path = "../ykpack" }
+
+[features]
+testing = []

--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -13,7 +13,7 @@ use ykpack::{
     self, BinOp, Body, CallOperand, Constant, ConstantInt, IRPlace, Local, Statement, Terminator,
     TyKind, UnsignedInt, UnsignedIntTy,
 };
-use yktrace::sir::{INTERP_STEP_ARG, RETURN_LOCAL, SIR};
+use yktrace::sir::{RETURN_LOCAL, SIR};
 
 /// Stores information needed to recreate stack frames in the StopgapInterpreter.
 pub struct FrameInfo {
@@ -262,9 +262,15 @@ impl StopgapInterpreter {
     }
 
     /// Inserts a pointer to the interpreter context into the `interp_step` frame.
+    #[cfg(feature = "testing")]
     pub unsafe fn set_interp_ctx(&mut self, ctx: *mut u8) {
         // The interpreter context lives in $1
-        let ptr = self.frames.first().unwrap().mem.local_ptr(&INTERP_STEP_ARG);
+        let ptr = self
+            .frames
+            .first()
+            .unwrap()
+            .mem
+            .local_ptr(&yktrace::sir::INTERP_STEP_ARG);
         std::ptr::write::<*mut u8>(ptr as *mut *mut u8, ctx);
     }
 

--- a/internal_ws/ykshim/Cargo.toml
+++ b/internal_ws/ykshim/Cargo.toml
@@ -14,3 +14,6 @@ yksg = { path = "../yksg" }
 ykcompile = { path = "../ykcompile" }
 ykpack = { path = "../ykpack" }
 yktrace = { path = "../yktrace" }
+
+[features]
+testing = ["yksg/testing"]

--- a/internal_ws/ykshim/src/lib.rs
+++ b/internal_ws/ykshim/src/lib.rs
@@ -3,6 +3,7 @@
 //! For more information, see this section in the documentation:
 //! https://softdevteam.github.io/ykdocs/tech/yk_structure.html
 
+#[cfg(feature = "testing")]
 mod test_api;
 
 use std::ffi::{c_void, CString};

--- a/internal_ws/ykshim/src/test_api.rs
+++ b/internal_ws/ykshim/src/test_api.rs
@@ -1,6 +1,7 @@
 //! The ykshim testing API.
 //!
 //! These functions are only exposed to allow testing from the external workspace.
+#![cfg(feature = "testing")]
 
 use libc::size_t;
 use std::convert::TryFrom;
@@ -113,6 +114,7 @@ unsafe extern "C" fn __ykshimtest_find_symbol(sym: *const c_char) -> *mut c_void
 
 /// Interpret a SIR body with the specified interpreter context.
 #[no_mangle]
+#[cfg(feature = "testing")]
 unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *const c_char, ctx: *mut u8) {
     let fname = CStr::from_ptr(body_name).to_str().unwrap().to_string();
     let mut si = StopgapInterpreter::from_symbol(fname);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 fm = "0.2.0"
-ykshim_client = { path = "../ykshim_client" }
+ykshim_client = { path = "../ykshim_client", features=["testing"] }
 libc = "0.2.82"
 paste = "1.0"
 regex = "1.4.3"

--- a/ykshim_client/Cargo.toml
+++ b/ykshim_client/Cargo.toml
@@ -7,3 +7,6 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = "0.2.82"
+
+[features]
+testing = []

--- a/ykshim_client/src/lib.rs
+++ b/ykshim_client/src/lib.rs
@@ -16,7 +16,9 @@ use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::{mem, ptr};
 
+#[cfg(feature = "testing")]
 mod test_api;
+#[cfg(feature = "testing")]
 pub use test_api::*;
 
 pub(crate) type RawCompiledTrace = c_void;

--- a/ykshim_client/src/test_api.rs
+++ b/ykshim_client/src/test_api.rs
@@ -1,4 +1,5 @@
 //! The testing API client to ykshim.
+#![cfg(feature = "testing")]
 
 use crate::{CompiledTrace, Local, RawCompiledTrace, RawSirTrace, RawTirTrace, SirTrace, TyIndex};
 use libc::size_t;


### PR DESCRIPTION
**This is a draft PR -- do not merge yet**

What we would like to do is mark some things (e.g. yksg's `set_interp_ctx` function) as `#[cfg(test)]` but since we have a cross-crate testing dependency (which is exacerbated, though not entirely caused by, the internal/external
workspace split), that doesn't work.

This commit adds a "testing" feature which is intended as yk's cross-crate substitute for "#[cfg(test)]". It enables us to a) clearly mark some parts of the code as only being necessary for testing b) only build those when the "testing" feature is enabled.

This does lead to some ugliness e.g. because we can't, as far as I know, conditionally compile a module, we have to stuff the contents of the "test_api.rs" modules into sub-modules. We also have to fiddle with our xtask build so that it passes down the "testing" feature. But, overall, I think the ugliness is probably worth the gain.

Addresses the spirit of (but not always the original text of!) https://github.com/softdevteam/yk/issues/277