### PR TITLE
Add tests for binary operations with constant arguments.

### DIFF
--- a/internal_ws/ykcompile/src/arch/x86_64/mod.rs
+++ b/internal_ws/ykcompile/src/arch/x86_64/mod.rs
@@ -127,7 +127,7 @@ macro_rules! binop_mul_div {
     //
     //   Encoding       Semantics
     //   --------------------------------------------------------------------
-    //   MUL r/m8:      AX * r/m8          AX <- result
+    //   MUL r/m8:      AL * r/m8          AX <- result
     //   MUL r/m16:     AX * r/m16         DX:AX <- result
     //   MUL r/m32:     EAX * r/m32        EDX:EAX <- result
     //   MUL r/m64:     RAX * r/m64        RDX:RAX <- result
@@ -138,8 +138,8 @@ macro_rules! binop_mul_div {
     //   DIV r/m64:     RDX:RAX * r/m64    RAX <- quotient, RDX <- remainder
     //
     // A couple of thing to note:
-    //   - Both MUL and DIV's first (implicit) operand is twice as large as the second (explicit)
-    //     operand. For all but r/m8 variants, the operand extends into RDX.
+    //   - DIV's first (implicit) operand is twice as large as the second (explicit) operand and
+    //     for all but the r/m8 variant, the operand extends into (some subset of) RDX.
     //   - Similarly, the result of both MUL and DIV is twice as large as the second operand.
     //
     // SIR only deals with same-sized operands and doesn't require us to capture the remainder for
@@ -195,15 +195,17 @@ macro_rules! binop_mul_div {
                     } else {
                         (src_r, false)
                     };
-                    // Set unused extended operand space to zero.
-                    if size == 1 {
-                        dynasm!(self.asm
-                            ; and ax, 0xff
-                        );
-                    } else {
-                        dynasm!(self.asm
-                            ; xor rdx, rdx
-                        );
+                    // Set DIV's unused extended operand space to zero.
+                    if stringify!($op) == "div" {
+                        if size == 1 {
+                            dynasm!(self.asm
+                                ; and ax, 0x00ff
+                            );
+                        } else {
+                            dynasm!(self.asm
+                                ; xor rdx, rdx
+                            );
+                        }
                     }
                     match size {
                         1 => {
@@ -237,10 +239,17 @@ macro_rules! binop_mul_div {
                 },
                 Location::Mem(..) => todo!(),
                 Location::Const { val, .. } => {
-                    if size > 1 {
-                        dynasm!(self.asm
-                            ; xor rdx, rdx
-                        );
+                    // Set DIV's unused extended operand space to zero.
+                    if stringify!($op) == "div" {
+                        if size == 1 {
+                            dynasm!(self.asm
+                                ; and ax, 0x00ff
+                            );
+                        } else {
+                            dynasm!(self.asm
+                                ; xor rdx, rdx
+                            );
+                        }
                     }
                     // It's safe to use TEMP_REG here, because opnd2 isn't in a register and if
                     // opnd1_reg was TEMP_REG then we've already moved it into RAX.

--- a/internal_ws/ykcompile/src/arch/x86_64/store.rs
+++ b/internal_ws/ykcompile/src/arch/x86_64/store.rs
@@ -100,21 +100,9 @@ impl TraceCompiler {
             },
             (Location::Reg(dst_reg), Location::Const { val: c_val, .. }) => {
                 let i64_c = c_val.i64_cast();
-                if i64_c <= i64::from(u32::MAX) {
-                    dynasm!(self.asm
-                        ; mov Rq(dst_reg), i64_c as i32
-                    );
-                } else {
-                    // Can't move 64-bit constants in x86_64.
-                    let i64_c = c_val.i64_cast();
-                    let hi_word = (i64_c >> 32) as i32;
-                    let lo_word = (i64_c & 0xffffffff) as i32;
-                    dynasm!(self.asm
-                        ; mov Rq(dst_reg), hi_word
-                        ; shl Rq(dst_reg), 32
-                        ; or Rq(dst_reg), lo_word
-                    );
-                }
+                dynasm!(self.asm
+                    ; mov Rq(dst_reg), QWORD i64_c
+                );
             }
             (Location::Mem(ro), Location::Const { val: c_val, ty }) => {
                 let c_i64 = c_val.i64_cast();


### PR DESCRIPTION
Shakes out a couple of bugs:
 - Something wrong with loading 64-bit constants into registers.
 - Forgot to zero unused argument space for binops on constant bytes.

[We now have 287 binop tests!]