### PR TITLE
Implement trace stitching.

### DIFF
--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -150,6 +150,7 @@ macro_rules! make_binop {
             let (v, of) = match op {
                 BinOp::Add => a.overflowing_add(b),
                 BinOp::Lt => ($type::from(a < b), false),
+                BinOp::Gt => ($type::from(a > b), false),
                 _ => todo!(),
             };
             if checked {
@@ -191,6 +192,7 @@ struct StackFrame {
 pub struct StopgapInterpreter {
     /// Active stack frames (most recent last).
     frames: Vec<StackFrame>,
+    returnval: bool,
 }
 
 impl StopgapInterpreter {
@@ -199,6 +201,7 @@ impl StopgapInterpreter {
         let frame = StopgapInterpreter::create_frame(&sym);
         StopgapInterpreter {
             frames: vec![frame],
+            returnval: true,
         }
     }
 
@@ -220,7 +223,10 @@ impl StopgapInterpreter {
             };
             frames.push(frame);
         }
-        let mut sg = StopgapInterpreter { frames };
+        let mut sg = StopgapInterpreter {
+            frames,
+            returnval: true,
+        };
         let frame = sg.frames.last().unwrap();
         // Since we start in the block where the guard failed, we immediately skip to the
         // terminator and interpret it to initialise the block where actual interpretation needs to
@@ -276,7 +282,7 @@ impl StopgapInterpreter {
         std::ptr::write::<*mut u8>(ptr as *mut *mut u8, ctx);
     }
 
-    pub unsafe fn interpret(&mut self) {
+    pub unsafe fn interpret(&mut self) -> bool {
         while let Some(frame) = self.frames.last() {
             let body = frame.body.clone();
             let block = &body.blocks[usize::try_from(frame.bbidx).unwrap()];
@@ -301,6 +307,7 @@ impl StopgapInterpreter {
             }
             self.terminator(&block.term);
         }
+        self.returnval
     }
 
     unsafe fn terminator(&mut self, term: &Terminator) {
@@ -345,6 +352,11 @@ impl StopgapInterpreter {
                     let size = usize::try_from(SIR.ty(&dst.ty()).size()).unwrap();
                     std::ptr::copy(ret_ptr, dst_ptr, size);
                     curframe.bbidx = bbidx;
+                } else {
+                    // The return value of `interp_step` tells the meta-tracer whether to stop or
+                    // continue running the interpreter.
+                    let ret_ptr = oldframe.mem.local_ptr(&RETURN_LOCAL);
+                    self.returnval = std::ptr::read::<bool>(ret_ptr as *const bool);
                 }
             }
             Terminator::SwitchInt {

--- a/internal_ws/ykshim/src/lib.rs
+++ b/internal_ws/ykshim/src/lib.rs
@@ -106,9 +106,9 @@ unsafe fn __ykshim_tirtrace_drop(tir_trace: *mut TirTrace) {
 
 /// Start an initialised StopgapInterpreter.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_si_interpret(si: *mut yksg::StopgapInterpreter) {
+unsafe extern "C" fn __ykshim_si_interpret(si: *mut yksg::StopgapInterpreter) -> bool {
     let si = &mut *si;
-    si.interpret();
+    si.interpret()
 }
 
 #[no_mangle]

--- a/tests/src/stopgap/guard_fail.rs
+++ b/tests/src/stopgap/guard_fail.rs
@@ -15,9 +15,10 @@ fn simple() {
     }
 
     #[interp_step]
-    fn interp_step(io: &mut InterpCtx) {
+    fn interp_step(io: &mut InterpCtx) -> bool {
         let x = guard(io.0);
         io.1 = x;
+        true
     }
 
     let mut ctx = InterpCtx(std::hint::black_box(|i| i)(0), 0);
@@ -60,9 +61,10 @@ fn recursion() {
     }
 
     #[interp_step]
-    fn interp_step(io: &mut InterpCtx) {
+    fn interp_step(io: &mut InterpCtx) -> bool {
         let x = rec(io.0, io.1);
         io.1 = x;
+        true
     }
 
     let mut ctx = InterpCtx(std::hint::black_box(|i| i)(0), 0);
@@ -100,9 +102,10 @@ fn recursion2() {
     }
 
     #[interp_step]
-    fn interp_step(io: &mut InterpCtx) {
+    fn interp_step(io: &mut InterpCtx) -> bool {
         let x = rec(io.0);
         io.1 = x;
+        true
     }
 
     let mut ctx = InterpCtx(7, 0);
@@ -124,4 +127,32 @@ fn recursion2() {
     let mut si: StopgapInterpreter = StopgapInterpreter(ptr);
     unsafe { si.interpret() };
     assert_eq!(args.1, 5);
+}
+
+#[test]
+fn trace_stitching() {
+    struct InterpCtx(u8);
+
+    #[interp_step]
+    fn interp_step(io: &mut InterpCtx) -> bool {
+        if io.0 < 100 {
+            io.0 += 1;
+            return false;
+        }
+        true
+    }
+
+    let mut ctx = InterpCtx(0);
+    #[cfg(tracermode = "hw")]
+    let th = start_tracing(TracingKind::HardwareTracing);
+    #[cfg(tracermode = "sw")]
+    let th = start_tracing(TracingKind::SoftwareTracing);
+    interp_step(&mut ctx);
+    let sir_trace = th.stop_tracing().unwrap();
+    let ct = compile_trace(sir_trace).unwrap();
+    let mut args = InterpCtx(0);
+    // With trace stitching, calling the trace once will loop until the `interp_step` function
+    // returns true.
+    unsafe { ct.execute(&mut args) };
+    assert_eq!(args.0, 100);
 }

--- a/ykshim_client/src/lib.rs
+++ b/ykshim_client/src/lib.rs
@@ -50,7 +50,7 @@ extern "C" {
     fn __ykshim_compiled_trace_get_ptr(compiled_trace: *const RawCompiledTrace) -> *const c_void;
     fn __ykshim_compiled_trace_drop(compiled_trace: *mut RawCompiledTrace);
     fn __ykshim_sirtrace_drop(trace: *mut RawSirTrace);
-    fn __ykshim_si_interpret(interp: *mut RawStopgapInterpreter);
+    fn __ykshim_si_interpret(interp: *mut RawStopgapInterpreter) -> bool;
     fn __ykshim_sirinterpreter_drop(interp: *mut RawStopgapInterpreter);
 }
 
@@ -98,8 +98,8 @@ impl Drop for ThreadTracer {
 pub struct StopgapInterpreter(pub *mut RawStopgapInterpreter);
 
 impl StopgapInterpreter {
-    pub unsafe fn interpret(&mut self) {
-        __ykshim_si_interpret(self.0);
+    pub unsafe fn interpret(&mut self) -> bool {
+        __ykshim_si_interpret(self.0)
     }
 }
 


### PR DESCRIPTION
Currently, we return after each trace execution back to the meta-tracer,
only for it to run the same trace again. Instead, we can just stitch
together the compiled trace, so that it loops indefinitely until a guard
fails.

The API for this very basic. The `interp_step` function is now required
to return a bool. If a traced path through the function returns `true`,
this means the interpreter is finished and we return; if a path returns
`false`, this means trace stitching is enabled for that trace and it can
only be exited via a guard.

Typically this means interpreter authors want to do something similar to
this:

```rust
fn interp_step(io: &mut Ctx) -> bool {
    // do interpreter stuff
    if some_abort_condition {
        return true;
    }
    false // loop forever
}
```