### PR TITLE
Try to clarify the documentation around the stopgap FramesVec.

### DIFF
--- a/internal_ws/ykcompile/src/arch/x86_64/mod.rs
+++ b/internal_ws/ykcompile/src/arch/x86_64/mod.rs
@@ -1346,7 +1346,7 @@ impl TraceCompiler {
             // Symbol names of the functions called while executing the trace. Needed to recreate
             // the stack frames in the StopgapInterpreter.
             let mut sym_labels = Vec::new();
-            for block in &guard.block {
+            for block in &guard.blocks {
                 let dynlbl = self.asm.new_dynamic_label();
                 dynasm!(self.asm
                     ; => dynlbl
@@ -1399,7 +1399,7 @@ impl TraceCompiler {
 
             // Second we iterate over all the functions that are "active" at the point of the
             // guard: each maps to a new stack frame.
-            for (i, block) in guard.block.iter().enumerate() {
+            for (i, block) in guard.blocks.iter().enumerate() {
                 let sym = block.symbol_name;
                 let bbidx = block.bb_idx;
                 let body = SIR.body(sym).unwrap();

--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -25,7 +25,7 @@ pub struct FrameInfo {
     /// terminator of this block is were we continue.
     pub bbidx: usize,
     /// Pointer to memory containing the live variables.
-    pub mem: *mut u8,
+    pub locals: *mut u8,
 }
 
 /// Heap allocated memory for writing and reading locals of a stack frame.
@@ -209,7 +209,7 @@ impl StopgapInterpreter {
         for fi in v {
             let body = &fi.body;
             let mem = LocalMem {
-                locals: fi.mem,
+                locals: fi.locals,
                 offsets: body.offsets.clone(),
                 layout: Layout::from_size_align(body.layout.0, body.layout.1).unwrap(),
             };


### PR DESCRIPTION
I'm not 100% sure my updates are correct. I also think we leak the memory in FrameInfo::mem -- we `alloc` memory but I can't see a corresponding `dealloc`. Indeed, I think we'd need to pass size/align around for that to work but that's rather tricky at the moment as with the x86_64 SysV ABI we only have 1 "easy" paramater register left...