### PR TITLE
Build ykrustc instead of using a binary snapshot.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -8,21 +8,7 @@ case ${CI_TRACER_KIND} in
        exit 1;;
 esac
 
-export RUSTFLAGS="-C tracer=${CI_TRACER_KIND} -D warnings"
-
-# Use the most recent successful ykrustc build.
-tar jxf /opt/ykrustc-bin-snapshots/ykrustc-${CI_TRACER_KIND}-stage2-latest.tar.bz2
-export PATH=`pwd`/ykrustc-stage2-latest/bin:${PATH}
-
-# Test both workspaces.
-cargo xtask test
-cargo xtask bench
-cargo xtask clean
-
-# Also test the build without xtask, as that's what consumers will do.
-cargo build
-
-unset RUSTFLAGS
+# Install rustup.
 export CARGO_HOME="`pwd`/.cargo"
 export RUSTUP_HOME="`pwd`/.rustup"
 export RUSTUP_INIT_SKIP_PATH_CHECK="yes"
@@ -33,5 +19,26 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu \
     --profile minimal \
     -y
 export PATH=${CARGO_HOME}/bin/:$PATH
+
+# Run rustfmt.
+# Note that xtask requires us to use a nightly toolchain for this step.
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo xtask fmt --all -- --check
+
+# Build the compiler and add it as a linked toolchain.
+git clone https://github.com/softdevteam/ykrustc
+cd ykrustc
+cp .buildbot.config.toml config.toml
+./x.py build --stage 1
+rustup toolchain link ykrustc-stage1 `pwd`/build/x86_64-unknown-linux-gnu/stage1
+cd ..
+rustup override set ykrustc-stage1
+
+# Test both workspaces using the compiler we just built.
+export RUSTFLAGS="-C tracer=${CI_TRACER_KIND} -D warnings"
+cargo xtask test
+cargo xtask bench
+cargo xtask clean
+
+# Also test the build without xtask, as that's what consumers will do.
+cargo build


### PR DESCRIPTION
This means that we can detect changes in yk which would break the compiler build. A couple instances of that happening have arisen recently.