### PR TITLE
Fix incorrect assertion.

### DIFF
--- a/internal_ws/ykpack/src/types.rs
+++ b/internal_ws/ykpack/src/types.rs
@@ -132,6 +132,10 @@ impl Ty {
         }
     }
 
+    pub fn is_bool(&self) -> bool {
+        self.kind == TyKind::Bool
+    }
+
     /// Unwraps a tuple if `self` is `Self::Tuple` or panics otherwise.
     pub fn unwrap_tuple(&self) -> &TupleTy {
         if let TyKind::Tuple(tty) = &self.kind {

--- a/internal_ws/yktrace/src/tir.rs
+++ b/internal_ws/yktrace/src/tir.rs
@@ -226,7 +226,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                         _,
                     ) = op
                     {
-                        debug_assert!(sir.ty(&rnm.local_decls[&sir::RETURN_LOCAL].ty).is_unit());
+                        debug_assert!(sir.ty(&rnm.local_decls[&sir::RETURN_LOCAL].ty).is_bool());
                         continue;
                     }
 


### PR DESCRIPTION
The interp_step must now return a bool.

We've not noticed this because the internal workspace is currently
always built *without* debug assertions. I'm working on a branch which
decides whether to build with debug assertions based upon the presence
or absence of --release. That's how I found this.

Fixes #293 