### PR TITLE
Remove unused code.

### DIFF
--- a/internal_ws/ykpack/src/types.rs
+++ b/internal_ws/ykpack/src/types.rs
@@ -590,16 +590,6 @@ pub enum ConstantInt {
     SignedInt(SignedInt),
 }
 
-impl From<bool> for ConstantInt {
-    fn from(b: bool) -> Self {
-        if b {
-            ConstantInt::UnsignedInt(UnsignedInt::Usize(1))
-        } else {
-            ConstantInt::UnsignedInt(UnsignedInt::Usize(0))
-        }
-    }
-}
-
 impl ConstantInt {
     /// Returns an i64 value suitable for loading into a register.
     /// If the constant is signed, then it will be sign-extended.


### PR DESCRIPTION
It seemed rather odd to me that a constant bool would end up being converted to a usize, but I couldn't see it causing problems. That appears to be because this function isn't actually called from yk or ykrustc.