### PR TITLE
Move away from a generic, and easy to get wrong, read_int function.

### DIFF
--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -383,13 +383,23 @@ impl StopgapInterpreter {
                 expected,
                 target_bb,
             } => {
-                let b = self.read_int(cond) == 1;
-                if b != *expected {
-                    todo!() // FIXME raise error
+                if self.read_bool(cond) != *expected {
+                    todo!();
                 }
                 self.frames.last_mut().unwrap().bbidx = *target_bb;
             }
             t => todo!("{}", t),
+        }
+    }
+
+    fn read_bool(&self, src: &IRPlace) -> bool {
+        if let IRPlace::Const { val: Constant::Int(ConstantInt::UnsignedInt(UnsignedInt::U8(v))), ty: _ } = src {
+            *v != 0
+        } else if let TyKind::Bool = SIR.ty(&src.ty()).kind {
+            let ptr = self.locals().irplace_to_ptr(src);
+            unsafe { std::ptr::read::<u8>(ptr) != 0 }
+        } else {
+            unreachable!();
         }
     }
 


### PR DESCRIPTION
`read_int` is a type-mangling function that expects to convert any constant
integer, or an integer read from memory, to a u128. This effectively turns any
code that calls the function into dynamic typing mode, and is likely to cause
various problems (e.g. with bitwise operations).

This commit breaks out read_bool as a separate function, as it's clearly
different than "normal" integer operations. However this doesn't currently work
as, on b13 at least, it "reads" values of 210 (not 0 or 1) from a byte in one
test! This suggests that the `Terminator::Assert` code only previously worked by
accident because we effectively tested "is <0 or 1> != 210" which of course
always produced `false`.