### PR TITLE
Make the release cargo profile work.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -27,6 +27,9 @@ cargo xtask fmt --all -- --check
 
 # Build the compiler and add it as a linked toolchain.
 git clone https://github.com/softdevteam/ykrustc
+# Prevent cargo walking up the filesystem and picking up the yk cargo config.
+# This leads to all kinds of chaos (slow build, linkage errors).
+mv .cargo/config.toml .cargo/config.toml.save
 cd ykrustc
 cat <<EOD >> Cargo.toml
 [patch."https://github.com/softdevteam/yk"]
@@ -36,6 +39,7 @@ cp .buildbot.config.toml config.toml
 ./x.py build --stage 1
 rustup toolchain link ykrustc-stage1 `pwd`/build/x86_64-unknown-linux-gnu/stage1
 cd ..
+mv .cargo/config.toml.save .cargo/config.toml
 rustup override set ykrustc-stage1
 
 # Test both workspaces using the compiler we just built.

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[alias]
-xtask = "run --package xtask --"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[alias]
+xtask = "run --package xtask --"
+
+# FIXME for software tracing we could optimise.
+[profile.release]
+opt-level = 0
+
+[profile.bench]
+opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ exclude = [ "internal_ws" ]
 
 [profile.dev]
 panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/internal_ws/.cargo/config.toml
+++ b/internal_ws/.cargo/config.toml
@@ -1,0 +1,9 @@
+# cargo will walk up the filesystem and find the external workspace's config
+# which disables optimisation. We don't want that for the internal workspace,
+# so we force the opt-levels back to their default values.
+
+[profile.release]
+opt-level = 3
+
+[profile.bench]
+opt-level = 3

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -5,9 +5,11 @@ fn main() {
         .file("src/test_helpers.c")
         .compile("ykcompile_test_helpers");
 
+    let profile = env::var("PROFILE").unwrap();
     println!(
-        "cargo:rustc-link-search={}/../internal_ws/target/release/",
-        env::current_dir().unwrap().to_str().unwrap()
+        "cargo:rustc-link-search={}/../internal_ws/target/{}/",
+        env::current_dir().unwrap().to_str().unwrap(),
+        profile
     );
     println!("cargo:rustc-link-lib=dylib=ykshim");
 }

--- a/tests/src/codegen/mod.rs
+++ b/tests/src/codegen/mod.rs
@@ -433,6 +433,7 @@ mk_binop_test!(binop_div5, /, u32, 1048576, 8, 131072);
 mk_binop_test!(binop_div6, /, u64, 68719476736u64, 8, 8589934592);
 
 #[test]
+#[cfg(debug_assertions)]
 fn binop_add_overflow() {
     #[derive(Eq, PartialEq, Debug)]
     struct InterpCtx(u8, u8);

--- a/tests/src/tir.rs
+++ b/tests/src/tir.rs
@@ -71,6 +71,7 @@ fn trace_debug_tir() {
     let sir_trace = tracer.stop_tracing().unwrap();
     let tir_trace = TirTrace::new(&sir_trace);
     assert_eq!(io.1, 38);
+    #[cfg(debug_assertions)]
     assert_tir(
         "...\n\
             ops:\n\
@@ -90,6 +91,29 @@ fn trace_debug_tir() {
               // Minus 2
               ...
               ... - 2usize (checked)
+              ...",
+        &tir_trace,
+    );
+    #[cfg(not(debug_assertions))]
+    assert_tir(
+        "...\n\
+            ops:\n\
+              ...
+              // Add 10
+              ...
+              ... + 10usize
+              ...
+              // Add 10
+              ...
+              ... + 10usize
+              ...
+              // Multiply 2
+              ...
+              ... * 2usize
+              ...
+              // Minus 2
+              ...
+              ... - 2usize
               ...",
         &tir_trace,
     );

--- a/ykrt/build.rs
+++ b/ykrt/build.rs
@@ -12,6 +12,7 @@ fn main() {
     internal_dir.push("..");
     internal_dir.push("internal_ws");
     let cargo = env::var("CARGO").unwrap();
+    let profile = env::var("PROFILE").unwrap();
 
     // Only build the internal workspace now if we are not using xtask, i.e. if we are being
     // consumed as a dependency. This means we see the compiler output for the internal workspace
@@ -20,17 +21,18 @@ fn main() {
         let mut rustflags = env::var("RUSTFLAGS").unwrap_or_else(|_| String::new());
         let tracing_kind = find_tracing_kind(&rustflags);
         rustflags = make_internal_rustflags(&rustflags);
-        let status = Command::new(cargo)
-            .current_dir(internal_dir.join("ykshim"))
+        let mut cmd = Command::new(cargo);
+        cmd.current_dir(internal_dir.join("ykshim"))
             .arg("build")
-            .arg("--release")
-            .env("RUSTFLAGS", &rustflags)
             .arg("--features")
             .arg(format!("yktrace/trace_{}", tracing_kind))
-            .spawn()
-            .unwrap()
-            .wait()
-            .unwrap();
+            .env("RUSTFLAGS", &rustflags);
+
+        if profile == "release" {
+            cmd.arg("--release");
+        }
+
+        let status = cmd.spawn().unwrap().wait().unwrap();
         if !status.success() {
             eprintln!("building internal workspace failed");
             std::process::exit(1);
@@ -47,14 +49,15 @@ fn main() {
     if !PathBuf::from(&sym_dst).exists() {
         let mut sym_src = internal_dir;
         sym_src.push("target");
-        sym_src.push("release");
+        sym_src.push(&profile);
         sym_src.push(YKSHIM_SO);
         symlink(sym_src, sym_dst).unwrap();
     }
 
     println!(
-        "cargo:rustc-link-search={}/../internal_ws/target/release/",
-        env::current_dir().unwrap().to_str().unwrap()
+        "cargo:rustc-link-search={}/../internal_ws/target/{}/",
+        env::current_dir().unwrap().to_str().unwrap(),
+        profile
     );
     println!("cargo:rustc-link-lib=dylib=ykshim");
 }


### PR DESCRIPTION
Currently the internal workspace is always built in release mode and the
external workspace cannot be built in release mode at all (it would
build the external workspace with LLVM optimisations that hardware
tracing cannot tolerate).

This change:

 a) Enables the use of --release with `cargo xtask`. In release mode,
    the external workspace is still *not* optimised, but other release
    mode settings *are* used (e.g. unchecked operations are used, and
    debug assertions are disabled).

 b) Makes it so that the internal workspace is only built in release
    mode if `--release` is passed to xtask.

We also test both modes in CI now.

I checked that performance is unaffected when tested with --release and
that performance is worse if --release is absent (as the internal workspace
is no-longer optimised in that case).

Also checked that debug assertions can fail in the internal workspace
when using a debug build.

The only problem with this is that if software tracing is used, you
still get an unoptimised external workspace, which could in fact be
optimised. I've put a FIXME in the Cargo config to remind us the revisit
this later.