### PR TITLE
Fix race condition in tests.

### DIFF
--- a/ykrt/src/location.rs
+++ b/ykrt/src/location.rs
@@ -138,12 +138,14 @@ impl<I> Location<I> {
         }
     }
 
-    /// Locks this `State` with `Acquire` ordering. If the location moves to the Counting state
-    /// during execution, this will return `Err`.
+    /// Locks this `State` with `Acquire` ordering. If the location was in, or moves to, the
+    /// Counting state this will return `Err`.
     pub(crate) fn lock(&self) -> Result<State<I>, ()> {
         {
             let ls = self.load(Ordering::Relaxed);
-            debug_assert!(!ls.is_counting());
+            if ls.is_counting() {
+                return Err(());
+            }
             let new_ls = ls.with_lock().with_unparked();
             if self
                 .state


### PR DESCRIPTION
Just because a location is `IS_COUNTING` now doesn't mean it will be in the next load. The API for `lock()` took account of this but didn't follow through with it. Ironically the more-correct code makes the tests much simpler... Oh well.