### PR TITLE
Depub

### DIFF
--- a/internal_ws/ykcompile/src/arch/mod.rs
+++ b/internal_ws/ykcompile/src/arch/mod.rs
@@ -4,4 +4,4 @@
 compile_error!("Currently only linux x86_64 is supported.");
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-pub(crate) mod x86_64;
+pub(super) mod x86_64;

--- a/internal_ws/ykcompile/src/arch/x86_64/store.rs
+++ b/internal_ws/ykcompile/src/arch/x86_64/store.rs
@@ -7,7 +7,7 @@ use yktrace::sir::SIR;
 
 impl TraceCompiler {
     /// Store the value in `src_loc` into `dst_loc`.
-    pub(crate) fn store(&mut self, dst_ip: &IRPlace, src_ip: &IRPlace) {
+    pub(super) fn store(&mut self, dst_ip: &IRPlace, src_ip: &IRPlace) {
         let dst_loc = self.irplace_to_location(dst_ip);
         let src_loc = self.irplace_to_location(src_ip);
         debug_assert!(SIR.ty(&dst_ip.ty()).size() == SIR.ty(&src_ip.ty()).size());
@@ -15,7 +15,7 @@ impl TraceCompiler {
     }
 
     /// Stores src_loc into dst_loc.
-    pub(crate) fn store_raw(&mut self, dst_loc: &Location, src_loc: &Location, size: u64) {
+    pub(super) fn store_raw(&mut self, dst_loc: &Location, src_loc: &Location, size: u64) {
         // This is the one place in the compiler where we allow an explosion of cases over the
         // variants of `Location`. If elsewhere you find yourself matching over a pair of locations
         // you should try and re-work you code so it calls this.

--- a/internal_ws/ykcompile/src/stack_builder.rs
+++ b/internal_ws/ykcompile/src/stack_builder.rs
@@ -11,7 +11,7 @@ use dynasmrt::{x64::Rq::RBP, Register};
 use std::convert::{TryFrom, TryInto};
 
 #[derive(Default, Debug)]
-pub(crate) struct StackBuilder {
+pub(super) struct StackBuilder {
     /// Keeps track of how many bytes have been allocated.
     stack_top: u64,
 }
@@ -19,7 +19,7 @@ pub(crate) struct StackBuilder {
 impl StackBuilder {
     /// Allocate an object of given size and alignment on the stack, returning a `Location::Mem`
     /// describing the position of the allocation. The stack is assumed to grow down.
-    pub(crate) fn alloc(&mut self, size: u64, align: u64) -> Location {
+    pub(super) fn alloc(&mut self, size: u64, align: u64) -> Location {
         self.align(align);
         self.stack_top += size;
         Location::new_mem(RBP.code(), -i32::try_from(self.stack_top).unwrap())
@@ -32,7 +32,7 @@ impl StackBuilder {
     }
 
     /// Total allocated stack size in bytes.
-    pub(crate) fn size(&self) -> u32 {
+    pub(super) fn size(&self) -> u32 {
         self.stack_top.try_into().unwrap()
     }
 }

--- a/internal_ws/ykpack/src/types.rs
+++ b/internal_ws/ykpack/src/types.rs
@@ -230,7 +230,7 @@ pub struct TupleTy {
 }
 
 impl TupleTy {
-    pub fn is_unit(&self) -> bool {
+    fn is_unit(&self) -> bool {
         self.fields.offsets.is_empty()
     }
 }
@@ -306,7 +306,7 @@ pub struct Body {
     pub blocks: Vec<BasicBlock>,
     pub flags: BodyFlags,
     pub local_decls: Vec<LocalDecl>,
-    pub num_args: usize,
+    pub(super) num_args: usize,
     pub layout: (usize, usize),
     pub offsets: Vec<usize>,
 }
@@ -593,7 +593,7 @@ pub enum ConstantInt {
 impl ConstantInt {
     /// Returns an i64 value suitable for loading into a register.
     /// If the constant is signed, then it will be sign-extended.
-    pub fn i64_cast(&self) -> i64 {
+    fn i64_cast(&self) -> i64 {
         match self {
             ConstantInt::UnsignedInt(ui) => match ui {
                 UnsignedInt::U8(i) => *i as i64,

--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -30,7 +30,7 @@ pub struct FrameInfo {
 
 /// Heap allocated memory for writing and reading locals of a stack frame.
 #[derive(Debug)]
-pub struct LocalMem {
+pub(crate) struct LocalMem {
     /// Pointer to allocated memory containing a frame's locals.
     locals: *mut u8,
     /// The offset of each Local into locals.

--- a/internal_ws/yksg/src/lib.rs
+++ b/internal_ws/yksg/src/lib.rs
@@ -198,6 +198,7 @@ pub struct StopgapInterpreter {
 
 impl StopgapInterpreter {
     /// Initialise the interpreter from a symbol name.
+    #[cfg(feature = "testing")]
     pub fn from_symbol(sym: String) -> Self {
         let frame = StopgapInterpreter::create_frame(&sym);
         StopgapInterpreter {

--- a/internal_ws/yktrace/src/swt.rs
+++ b/internal_ws/yktrace/src/swt.rs
@@ -29,7 +29,7 @@ impl ThreadTracerImpl for SWTThreadTracer {
     }
 }
 
-pub(crate) fn start_tracing() -> ThreadTracer {
+pub(super) fn start_tracing() -> ThreadTracer {
     TRACE_BUF.with(|trace_buf| {
         assert!(trace_buf.is_empty());
     });

--- a/tests/src/helpers.rs
+++ b/tests/src/helpers.rs
@@ -5,14 +5,14 @@ use regex::Regex;
 use ykshim_client::{sir_body_ret_ty, TirTrace, TypeId};
 
 extern "C" {
-    pub fn add6(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64;
+    pub(super) fn add6(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64;
 }
 extern "C" {
-    pub fn add_some(a: u64, b: u64, c: u64, d: u64, e: u64) -> u64;
+    pub(super) fn add_some(a: u64, b: u64, c: u64, d: u64, e: u64) -> u64;
 }
 
 /// Fuzzy matches the textual TIR for the trace `tt` with the pattern `ptn`.
-pub fn assert_tir(ptn: &str, tt: &TirTrace) {
+pub(super) fn assert_tir(ptn: &str, tt: &TirTrace) {
     let ptn_re = Regex::new(r"%.+?\b").unwrap(); // Names are words prefixed with `%`.
     let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
     let matcher = FMBuilder::new(ptn)
@@ -28,7 +28,7 @@ pub fn assert_tir(ptn: &str, tt: &TirTrace) {
     }
 }
 
-pub fn neg_assert_tir(ptn: &str, tt: &TirTrace) {
+pub(super) fn neg_assert_tir(ptn: &str, tt: &TirTrace) {
     let ptn_re = Regex::new(r"%.+?\b").unwrap(); // Names are words prefixed with `%`.
     let text_re = Regex::new(r"\$?.+?\b").unwrap(); // Any word optionally prefixed with `$`.
     let matcher = FMBuilder::new(ptn)
@@ -46,17 +46,17 @@ pub fn neg_assert_tir(ptn: &str, tt: &TirTrace) {
 
 /// Types IDs that we need for tests.
 #[repr(C)]
-pub struct TestTypes {
-    pub t_u8: TypeId,
-    pub t_i64: TypeId,
-    pub t_string: TypeId,
-    pub t_tiny_struct: TypeId,
-    pub t_tiny_array: TypeId,
-    pub t_tiny_tuple: TypeId,
+pub(super) struct TestTypes {
+    pub(super) t_u8: TypeId,
+    pub(super) t_i64: TypeId,
+    pub(super) t_string: TypeId,
+    pub(super) t_tiny_struct: TypeId,
+    pub(super) t_tiny_array: TypeId,
+    pub(super) t_tiny_tuple: TypeId,
 }
 
 impl TestTypes {
-    pub fn new() -> TestTypes {
+    pub(super) fn new() -> TestTypes {
         // We can't know the type ID of any given type, so this works by defining unmangled
         // functions with known return types and then looking them up by name in the SIR.
         #[no_mangle]

--- a/tests/src/tracing.rs
+++ b/tests/src/tracing.rs
@@ -55,7 +55,7 @@ fn trace_twice() {
 
 /// Test that tracing in different threads works.
 #[test]
-pub(crate) fn trace_concurrent() {
+fn trace_concurrent() {
     #[cfg(tracermode = "hw")]
     let kind = TracingKind::HardwareTracing;
     #[cfg(tracermode = "sw")]

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(test, feature(test))]
 
 mod location;
-pub mod mt;
+pub(crate) mod mt;
 
 pub use self::location::Location;
 pub use self::mt::{MTBuilder, MT};

--- a/ykshim_client/src/lib.rs
+++ b/ykshim_client/src/lib.rs
@@ -32,9 +32,11 @@ pub type RawStopgapInterpreter = c_void;
 pub type LocalIndex = u32;
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 #[repr(C)]
+#[cfg(feature = "testing")]
 pub struct Local(pub LocalIndex);
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
+#[cfg(feature = "testing")]
 pub(crate) struct TyIndex(pub(crate) u32);
 
 extern "C" {
@@ -149,6 +151,7 @@ impl<I> CompiledTrace<I> {
     }
 
     /// Execute the trace with the given interpreter context.
+    #[cfg(feature = "testing")]
     pub unsafe fn execute(&self, ctx: &mut I) -> *mut RawStopgapInterpreter {
         let f = mem::transmute::<_, fn(&mut I) -> *mut RawStopgapInterpreter>(self.ptr());
         #[cfg(not(debug_assertions))]

--- a/ykshim_client/src/lib.rs
+++ b/ykshim_client/src/lib.rs
@@ -35,7 +35,7 @@ pub type LocalIndex = u32;
 pub struct Local(pub LocalIndex);
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct TyIndex(pub u32);
+pub(crate) struct TyIndex(pub(crate) u32);
 
 extern "C" {
     fn __ykshim_start_tracing(tracing_kind: u8) -> *mut RawThreadTracer;

--- a/ykshim_client/src/test_api.rs
+++ b/ykshim_client/src/test_api.rs
@@ -14,12 +14,12 @@ type RawTraceCompiler = c_void;
 // Keep these types in-sync with the internal workspace.
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct CguHash(u64);
+struct CguHash(u64);
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct TypeId {
-    pub cgu: CguHash,
-    pub idx: TyIndex,
+    cgu: CguHash,
+    idx: TyIndex,
 }
 
 extern "C" {
@@ -91,8 +91,8 @@ pub fn sir_body_ret_ty(sym: &str) -> TypeId {
 }
 
 pub struct LocalDecl {
-    pub ty: TypeId,
-    pub referenced: bool,
+    ty: TypeId,
+    referenced: bool,
 }
 
 impl LocalDecl {

--- a/ykshim_client/src/test_api.rs
+++ b/ykshim_client/src/test_api.rs
@@ -17,6 +17,7 @@ type RawTraceCompiler = c_void;
 struct CguHash(u64);
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
+#[cfg(feature = "testing")]
 pub struct TypeId {
     cgu: CguHash,
     idx: TyIndex,
@@ -49,6 +50,7 @@ extern "C" {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "testing")]
 pub struct TirTrace(*mut RawTirTrace);
 
 impl TirTrace {


### PR DESCRIPTION
Needs https://github.com/softdevteam/yk/pull/308 to be merged first. I'm raising this as useful context for https://github.com/softdevteam/depub/pull/1.

This PR uses https://github.com/softdevteam/depub/ to reduce the visibility of quite a lot more items in yk. In some cases, we only slightly reduce visibility (`pub(crate)` to `pub(super)`) but there are a reasonable number where we get rid of `pub` entirely. We're also able to gate a small number of items behind `#[cfg(feature="testing")]` to make clear when something is only needed for our (unusual) test setup. Overall, this PR has no functional change, but should make it a tiny little bit easier to understand the code base.