### PR TITLE
Rename ykshim.

### DIFF
--- a/traced/Cargo.toml
+++ b/traced/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "ykshim_client",
+    "untraced_api",
     "tests",
     "ykrt",
 ]

--- a/traced/tests/Cargo.toml
+++ b/traced/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 fm = "0.2.0"
-ykshim_client = { path = "../ykshim_client", features=["testing"] }
+untraced_api = { path = "../untraced_api", features=["testing"] }
 libc = "0.2.82"
 paste = "1.0"
 regex = "1.4.3"

--- a/traced/tests/build.rs
+++ b/traced/tests/build.rs
@@ -11,5 +11,5 @@ fn main() {
         env::current_dir().unwrap().to_str().unwrap(),
         profile
     );
-    println!("cargo:rustc-link-lib=dylib=ykshim");
+    println!("cargo:rustc-link-lib=dylib=to_traced");
 }

--- a/traced/tests/src/codegen/binops.rs
+++ b/traced/tests/src/codegen/binops.rs
@@ -2,7 +2,7 @@
 
 use super::{I16_MAX, I32_MAX, I64_MAX, U16_MAX, U32_MAX, U64_MAX};
 use paste::paste;
-use ykshim_client::{compile_trace, start_tracing, TracingKind};
+use untraced_api::{compile_trace, start_tracing, TracingKind};
 
 /// Generates a test for a binary operation.
 macro_rules! mk_binop_test {

--- a/traced/tests/src/codegen/cond_brs.rs
+++ b/traced/tests/src/codegen/cond_brs.rs
@@ -5,7 +5,7 @@ use super::{
     U32_MAX, U32_MIN, U64_MAX, U64_MIN, U8_MAX, U8_MIN,
 };
 use paste::paste;
-use ykshim_client::{compile_trace, start_tracing, TracingKind};
+use untraced_api::{compile_trace, start_tracing, TracingKind};
 
 /// Generates a test for a binary operation.
 macro_rules! mk_cond_br_tests {

--- a/traced/tests/src/codegen/mod.rs
+++ b/traced/tests/src/codegen/mod.rs
@@ -3,7 +3,7 @@
 use crate::helpers::{add6, add_some};
 use libc;
 use libc::{abs, getuid};
-use ykshim_client::{compile_tir_trace, compile_trace, start_tracing, TirTrace, TracingKind};
+use untraced_api::{compile_tir_trace, compile_trace, start_tracing, TirTrace, TracingKind};
 
 mod binops;
 mod cond_brs;

--- a/traced/tests/src/codegen/reg_alloc.rs
+++ b/traced/tests/src/codegen/reg_alloc.rs
@@ -2,7 +2,7 @@
 
 use crate::helpers::TestTypes;
 use std::{collections::HashMap, convert::TryFrom};
-use ykshim_client::{reg_pool_size, Local, LocalDecl, LocalIndex, TraceCompiler};
+use untraced_api::{reg_pool_size, Local, LocalDecl, LocalIndex, TraceCompiler};
 
 // Repeatedly fetching the register for the same local should yield the same register and
 // should not exhaust the allocator.

--- a/traced/tests/src/helpers.rs
+++ b/traced/tests/src/helpers.rs
@@ -2,7 +2,7 @@
 
 use fm::FMBuilder;
 use regex::Regex;
-use ykshim_client::{sir_body_ret_ty, TirTrace, TypeId};
+use untraced_api::{sir_body_ret_ty, TirTrace, TypeId};
 
 extern "C" {
     pub(super) fn add6(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64;

--- a/traced/tests/src/stopgap/guard_fail.rs
+++ b/traced/tests/src/stopgap/guard_fail.rs
@@ -1,6 +1,6 @@
 //! Testing the stopgap interpreter via guard failures.
 
-use ykshim_client::{compile_trace, start_tracing, StopgapInterpreter, TracingKind};
+use untraced_api::{compile_trace, start_tracing, StopgapInterpreter, TracingKind};
 
 #[test]
 fn simple() {

--- a/traced/tests/src/stopgap/interp.rs
+++ b/traced/tests/src/stopgap/interp.rs
@@ -1,6 +1,6 @@
 //! Artificially testing the stopgap interpreter (without a guard failure).
 
-use ykshim_client::interpret_body;
+use untraced_api::interpret_body;
 
 #[test]
 fn simple() {

--- a/traced/tests/src/symbols.rs
+++ b/traced/tests/src/symbols.rs
@@ -2,7 +2,7 @@
 
 use libc::{self, c_void};
 use std::ptr;
-use ykshim_client::find_symbol;
+use untraced_api::find_symbol;
 
 // Test finding a symbol in a shared object.
 #[test]

--- a/traced/tests/src/tir.rs
+++ b/traced/tests/src/tir.rs
@@ -2,8 +2,8 @@
 
 use crate::helpers::{add6, assert_tir, neg_assert_tir};
 use std::hint::black_box;
+use untraced_api::{start_tracing, TirTrace, TracingKind};
 use ykrt::trace_debug;
-use ykshim_client::{start_tracing, TirTrace, TracingKind};
 
 #[test]
 fn nonempty_tir_trace() {

--- a/traced/tests/src/tracing.rs
+++ b/traced/tests/src/tracing.rs
@@ -3,7 +3,7 @@
 // FIXME hard-coded hardware testing. Use default mode, but requires more shimming.
 
 use std::{hint::black_box, thread};
-use ykshim_client::{start_tracing, TracingKind};
+use untraced_api::{start_tracing, TracingKind};
 
 // Some work to trace.
 #[interp_step]

--- a/traced/untraced_api/Cargo.toml
+++ b/traced/untraced_api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ykshim_client"
+name = "untraced_api"
 version = "0.1.0"
 authors = ["The Yorick Developers"]
 edition = "2018"

--- a/traced/untraced_api/src/test_api.rs
+++ b/traced/untraced_api/src/test_api.rs
@@ -1,4 +1,4 @@
-//! The testing API client to ykshim.
+//! The testing API client to to_traced.
 #![cfg(feature = "testing")]
 
 use crate::{CompiledTrace, Local, RawCompiledTrace, RawSirTrace, RawTirTrace, SirTrace, TyIndex};
@@ -24,29 +24,29 @@ pub struct TypeId {
 }
 
 extern "C" {
-    fn __ykshimtest_compile_tir_trace(tir_trace: *mut RawTirTrace) -> *mut RawCompiledTrace;
-    fn __ykshimtest_sirtrace_len(sir_trace: *mut RawSirTrace) -> size_t;
-    fn __ykshimtest_tirtrace_new(sir_trace: *mut RawSirTrace) -> *mut RawTirTrace;
-    fn __ykshim_tirtrace_drop(tir_trace: *mut RawTirTrace);
-    fn __ykshimtest_tracecompiler_drop(comp: *mut RawTraceCompiler);
-    fn __ykshimtest_tirtrace_len(tir_trace: *mut RawTirTrace) -> size_t;
-    fn __ykshimtest_tirtrace_display(tir_trace: *mut RawTirTrace) -> *mut c_char;
-    fn __ykshimtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId);
-    fn __ykshimtest_tracecompiler_default() -> *mut RawTraceCompiler;
-    fn __ykshimtest_tracecompiler_insert_decl(
+    fn __to_tracedtest_compile_tir_trace(tir_trace: *mut RawTirTrace) -> *mut RawCompiledTrace;
+    fn __to_tracedtest_sirtrace_len(sir_trace: *mut RawSirTrace) -> size_t;
+    fn __to_tracedtest_tirtrace_new(sir_trace: *mut RawSirTrace) -> *mut RawTirTrace;
+    fn __to_traced_tirtrace_drop(tir_trace: *mut RawTirTrace);
+    fn __to_tracedtest_tracecompiler_drop(comp: *mut RawTraceCompiler);
+    fn __to_tracedtest_tirtrace_len(tir_trace: *mut RawTirTrace) -> size_t;
+    fn __to_tracedtest_tirtrace_display(tir_trace: *mut RawTirTrace) -> *mut c_char;
+    fn __to_tracedtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId);
+    fn __to_tracedtest_tracecompiler_default() -> *mut RawTraceCompiler;
+    fn __to_tracedtest_tracecompiler_insert_decl(
         tc: *mut RawTraceCompiler,
         local: Local,
         local_ty: TypeId,
         referenced: bool,
     );
-    fn __ykshimtest_tracecompiler_local_to_location_str(
+    fn __to_tracedtest_tracecompiler_local_to_location_str(
         tc: *mut RawTraceCompiler,
         local: Local,
     ) -> *mut c_char;
-    fn __ykshimtest_tracecompiler_local_dead(tc: *mut RawTraceCompiler, local: Local);
-    fn __ykshimtest_find_symbol(sym: *const c_char) -> *mut c_void;
-    fn __ykshimtest_interpret_body(body_name: *const c_char, ctx: *mut u8);
-    fn __ykshimtest_reg_pool_size() -> usize;
+    fn __to_tracedtest_tracecompiler_local_dead(tc: *mut RawTraceCompiler, local: Local);
+    fn __to_tracedtest_find_symbol(sym: *const c_char) -> *mut c_void;
+    fn __to_tracedtest_interpret_body(body_name: *const c_char, ctx: *mut u8);
+    fn __to_tracedtest_reg_pool_size() -> usize;
 }
 
 #[derive(Debug)]
@@ -55,7 +55,7 @@ pub struct TirTrace(*mut RawTirTrace);
 
 impl TirTrace {
     pub fn new(sir_trace: &SirTrace) -> Self {
-        Self(unsafe { __ykshimtest_tirtrace_new(sir_trace.0) })
+        Self(unsafe { __to_tracedtest_tirtrace_new(sir_trace.0) })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -63,21 +63,21 @@ impl TirTrace {
     }
 
     pub fn len(&self) -> usize {
-        unsafe { __ykshimtest_tirtrace_len(self.0) }
+        unsafe { __to_tracedtest_tirtrace_len(self.0) }
     }
 }
 
 impl Drop for TirTrace {
     fn drop(&mut self) {
         if !self.0.is_null() {
-            unsafe { __ykshim_tirtrace_drop(self.0) };
+            unsafe { __to_traced_tirtrace_drop(self.0) };
         }
     }
 }
 
 impl fmt::Display for TirTrace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let cstr = unsafe { CString::from_raw(__ykshimtest_tirtrace_display(self.0)) };
+        let cstr = unsafe { CString::from_raw(__to_tracedtest_tirtrace_display(self.0)) };
         write!(f, "{}", cstr.into_string().unwrap())
     }
 }
@@ -88,7 +88,7 @@ pub fn sir_body_ret_ty(sym: &str) -> TypeId {
         cgu: CguHash(0),
         idx: TyIndex(0),
     };
-    unsafe { __ykshimtest_body_ret_ty(sym_c.as_ptr(), &mut ret) };
+    unsafe { __to_tracedtest_body_ret_ty(sym_c.as_ptr(), &mut ret) };
     ret
 }
 
@@ -107,27 +107,27 @@ pub struct TraceCompiler(*mut c_void);
 
 impl TraceCompiler {
     pub fn new(local_decls: HashMap<Local, LocalDecl>) -> Self {
-        let tc = unsafe { __ykshimtest_tracecompiler_default() };
+        let tc = unsafe { __to_tracedtest_tracecompiler_default() };
         for (l, decl) in local_decls.iter() {
-            unsafe { __ykshimtest_tracecompiler_insert_decl(tc, *l, decl.ty, decl.referenced) };
+            unsafe { __to_tracedtest_tracecompiler_insert_decl(tc, *l, decl.ty, decl.referenced) };
         }
 
         Self(tc)
     }
 
     pub fn local_to_location_str(&mut self, local: Local) -> String {
-        let ptr = unsafe { __ykshimtest_tracecompiler_local_to_location_str(self.0, local) };
+        let ptr = unsafe { __to_tracedtest_tracecompiler_local_to_location_str(self.0, local) };
         String::from(unsafe { CString::from_raw(ptr).to_str().unwrap() })
     }
 
     pub fn local_dead(&mut self, local: Local) {
-        unsafe { __ykshimtest_tracecompiler_local_dead(self.0, local) };
+        unsafe { __to_tracedtest_tracecompiler_local_dead(self.0, local) };
     }
 }
 
 impl Drop for TraceCompiler {
     fn drop(&mut self) {
-        unsafe { __ykshimtest_tracecompiler_drop(self.0) }
+        unsafe { __to_tracedtest_tracecompiler_drop(self.0) }
     }
 }
 
@@ -137,21 +137,21 @@ impl SirTrace {
     }
 
     pub fn len(&self) -> usize {
-        unsafe { __ykshimtest_sirtrace_len(self.0) }
+        unsafe { __to_tracedtest_sirtrace_len(self.0) }
     }
 }
 
 pub fn interpret_body<I>(body_name: &str, ctx: &mut I) {
     let body_cstr = CString::new(body_name).unwrap();
-    unsafe { __ykshimtest_interpret_body(body_cstr.as_ptr(), ctx as *mut _ as *mut u8) };
+    unsafe { __to_tracedtest_interpret_body(body_cstr.as_ptr(), ctx as *mut _ as *mut u8) };
 }
 
 pub fn reg_pool_size() -> usize {
-    unsafe { __ykshimtest_reg_pool_size() }
+    unsafe { __to_tracedtest_reg_pool_size() }
 }
 
 pub fn compile_tir_trace<T>(mut tir_trace: TirTrace) -> Result<CompiledTrace<T>, CString> {
-    let compiled = unsafe { __ykshimtest_compile_tir_trace(tir_trace.0) };
+    let compiled = unsafe { __to_tracedtest_compile_tir_trace(tir_trace.0) };
     tir_trace.0 = ptr::null_mut(); // consumed.
     Ok(CompiledTrace {
         compiled,
@@ -161,5 +161,5 @@ pub fn compile_tir_trace<T>(mut tir_trace: TirTrace) -> Result<CompiledTrace<T>,
 
 pub fn find_symbol(sym: &str) -> *mut c_void {
     let sym_cstr = CString::new(sym).unwrap();
-    unsafe { __ykshimtest_find_symbol(sym_cstr.as_ptr()) }
+    unsafe { __to_tracedtest_find_symbol(sym_cstr.as_ptr()) }
 }

--- a/traced/ykrt/Cargo.toml
+++ b/traced/ykrt/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 parking_lot = "0.11"
 parking_lot_core = "0.8"
 strum = { version = "0.20", features = ["derive"] }
-ykshim_client = { path = "../ykshim_client" }
+untraced_api = { path = "../untraced_api" }
 
 [build-dependencies]
 regex = "1.4.3"

--- a/traced/ykrt/build.rs
+++ b/traced/ykrt/build.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 include!("../../build_aux.rs");
 
-const YKSHIM_SO: &str = "libykshim.so";
+const TO_TRACED_SO: &str = "libto_traced.so";
 
 fn main() {
     let mut untraced_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -23,7 +23,7 @@ fn main() {
         let tracing_kind = find_tracing_kind(&rustflags);
         rustflags = make_untraced_rustflags(&rustflags);
         let mut cmd = Command::new(cargo);
-        cmd.current_dir(untraced_dir.join("ykshim"))
+        cmd.current_dir(untraced_dir.join("to_traced"))
             .arg("build")
             .arg("--features")
             .arg(format!("yktrace/trace_{}", tracing_kind))
@@ -40,18 +40,18 @@ fn main() {
         }
     }
 
-    // If we symlink libykshim.so into the target dir, then this is already in the linker path when
+    // If we symlink libto_traced.so into the target dir, then this is already in the linker path when
     // run under cargo. In other words, the user won't have to set LD_LIBRARY_PATH.
     let mut sym_dst = PathBuf::from(env::var("OUT_DIR").unwrap());
     sym_dst.push("..");
     sym_dst.push("..");
     sym_dst.push("..");
-    sym_dst.push(YKSHIM_SO);
+    sym_dst.push(TO_TRACED_SO);
     if !PathBuf::from(&sym_dst).exists() {
         let mut sym_src = untraced_dir;
         sym_src.push("target");
         sym_src.push(&profile);
-        sym_src.push(YKSHIM_SO);
+        sym_src.push(TO_TRACED_SO);
         symlink(sym_src, sym_dst).unwrap();
     }
 
@@ -60,5 +60,5 @@ fn main() {
         env::current_dir().unwrap().to_str().unwrap(),
         profile
     );
-    println!("cargo:rustc-link-lib=dylib=ykshim");
+    println!("cargo:rustc-link-lib=dylib=to_traced");
 }

--- a/traced/ykrt/src/location.rs
+++ b/traced/ykrt/src/location.rs
@@ -15,7 +15,7 @@ use parking_lot_core::{
 };
 use strum::EnumDiscriminants;
 
-use ykshim_client::{CompiledTrace, ThreadTracer};
+use untraced_api::{CompiledTrace, ThreadTracer};
 
 use crate::mt::HotThreshold;
 

--- a/traced/ykrt/src/mt.rs
+++ b/traced/ykrt/src/mt.rs
@@ -21,7 +21,7 @@ use parking_lot::Mutex;
 use parking_lot_core::SpinWait;
 
 use crate::location::{HotLocation, Location, State, ThreadIdInner};
-use ykshim_client::{
+use untraced_api::{
     compile_trace, start_tracing, RawStopgapInterpreter, StopgapInterpreter, TracingKind,
 };
 

--- a/untraced/Cargo.toml
+++ b/untraced/Cargo.toml
@@ -3,7 +3,7 @@ members = [
     "ykcompile",
     "ykpack",
     "yksg",
-    "ykshim",
+    "to_traced",
     "yktrace",
     "ykview",
 ]

--- a/untraced/to_traced/Cargo.toml
+++ b/untraced/to_traced/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ykshim"
+name = "to_traced"
 version = "0.1.0"
 authors = ["The Yorick Developers"]
 edition = "2018"

--- a/untraced/to_traced/src/lib.rs
+++ b/untraced/to_traced/src/lib.rs
@@ -29,7 +29,7 @@ enum TracingKind {
 /// Starts tracing using the specified kind, returning a ThreadTracer through which to stop
 /// tracing.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_start_tracing(tracing_kind: u8) -> *mut ThreadTracer {
+unsafe extern "C" fn __to_traced_start_tracing(tracing_kind: u8) -> *mut ThreadTracer {
     let tracing_kind = match tracing_kind {
         0 => yktrace::TracingKind::SoftwareTracing,
         1 => yktrace::TracingKind::HardwareTracing,
@@ -43,7 +43,7 @@ unsafe extern "C" fn __ykshim_start_tracing(tracing_kind: u8) -> *mut ThreadTrac
 /// error occurs then the returned pointer will be NULL and `error_msg` will contain details of the
 /// error.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_stop_tracing(
+unsafe extern "C" fn __to_traced_stop_tracing(
     tracer: *mut ThreadTracer,
     error_msg: *mut *mut c_char,
 ) -> *mut SirTrace {
@@ -61,7 +61,7 @@ unsafe extern "C" fn __ykshim_stop_tracing(
 /// Compiles a SIR trace into an opaque pointer to a native code trace. If an error occurs, the
 /// returned pointer will be null, and `error_msg` will contain details of the error.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_compile_trace(
+unsafe extern "C" fn __to_traced_compile_trace(
     sir_trace: *mut SirTrace,
     error_msg: *mut *mut c_char,
 ) -> *mut CompiledTrace {
@@ -79,7 +79,7 @@ unsafe extern "C" fn __ykshim_compile_trace(
 
 /// Gets a callable function pointer from a compiled trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_compiled_trace_get_ptr(
+unsafe extern "C" fn __to_traced_compiled_trace_get_ptr(
     compiled_trace: *const CompiledTrace,
 ) -> *const c_void {
     let compiled_trace = &*(compiled_trace as *mut CompiledTrace);
@@ -88,30 +88,30 @@ unsafe extern "C" fn __ykshim_compiled_trace_get_ptr(
 
 /// Drop a compiled trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_compiled_trace_drop(compiled_trace: *mut CompiledTrace) {
+unsafe extern "C" fn __to_traced_compiled_trace_drop(compiled_trace: *mut CompiledTrace) {
     Box::from_raw(compiled_trace);
 }
 
 /// Drop a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_sirtrace_drop(trace: *mut SirTrace) {
+unsafe extern "C" fn __to_traced_sirtrace_drop(trace: *mut SirTrace) {
     Box::from_raw(trace);
 }
 
 /// Drop a TIR trace.
 #[no_mangle]
-unsafe fn __ykshim_tirtrace_drop(tir_trace: *mut TirTrace) {
+unsafe fn __to_traced_tirtrace_drop(tir_trace: *mut TirTrace) {
     Box::from_raw(tir_trace);
 }
 
 /// Start an initialised StopgapInterpreter.
 #[no_mangle]
-unsafe extern "C" fn __ykshim_si_interpret(si: *mut yksg::StopgapInterpreter) -> bool {
+unsafe extern "C" fn __to_traced_si_interpret(si: *mut yksg::StopgapInterpreter) -> bool {
     let si = &mut *si;
     si.interpret()
 }
 
 #[no_mangle]
-unsafe extern "C" fn __ykshim_sirinterpreter_drop(interp: *mut yksg::StopgapInterpreter) {
+unsafe extern "C" fn __to_traced_sirinterpreter_drop(interp: *mut yksg::StopgapInterpreter) {
     Box::from_raw(interp);
 }

--- a/untraced/to_traced/src/test_api.rs
+++ b/untraced/to_traced/src/test_api.rs
@@ -1,4 +1,4 @@
-//! The ykshim testing API.
+//! The to_traced testing API.
 //!
 //! These functions are only exposed to allow testing from the traced workspace.
 #![cfg(feature = "testing")]
@@ -18,13 +18,13 @@ use yktrace::tir::TirTrace;
 
 /// Returns the length of a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_sirtrace_len(sir_trace: *mut SirTrace) -> size_t {
+unsafe extern "C" fn __to_tracedtest_sirtrace_len(sir_trace: *mut SirTrace) -> size_t {
     (&mut *sir_trace).len()
 }
 
 /// Compile a TIR trace from a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tirtrace_new<'a, 'm>(
+unsafe extern "C" fn __to_tracedtest_tirtrace_new<'a, 'm>(
     sir_trace: *mut SirTrace,
 ) -> *mut TirTrace<'a, 'm> {
     let sir_trace = &mut *(sir_trace);
@@ -33,13 +33,15 @@ unsafe extern "C" fn __ykshimtest_tirtrace_new<'a, 'm>(
 
 /// Returns the length of a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tirtrace_len<'a, 'm>(tir_trace: *mut TirTrace<'a, 'm>) -> size_t {
+unsafe extern "C" fn __to_tracedtest_tirtrace_len<'a, 'm>(
+    tir_trace: *mut TirTrace<'a, 'm>,
+) -> size_t {
     (*tir_trace).len()
 }
 
 /// Returns the human-readable Display string of a TIR trace.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tirtrace_display<'a, 'm>(
+unsafe extern "C" fn __to_tracedtest_tirtrace_display<'a, 'm>(
     tir_trace: *mut TirTrace<'a, 'm>,
 ) -> *mut c_char {
     let tt = &(*tir_trace);
@@ -50,7 +52,7 @@ unsafe extern "C" fn __ykshimtest_tirtrace_display<'a, 'm>(
 /// Looks up the TypeId of the return value of the given symbol. The TypeId is returned via the
 /// `ret_tyid` argument.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId) {
+unsafe extern "C" fn __to_tracedtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId) {
     let sym = CStr::from_ptr(sym);
     let rv = usize::try_from(sir::RETURN_LOCAL.0).unwrap();
     let tyid = SIR.body(&sym.to_str().unwrap()).unwrap().local_decls[rv].ty;
@@ -59,20 +61,20 @@ unsafe extern "C" fn __ykshimtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut
 
 /// Creates a TraceCompiler with default settings.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tracecompiler_default() -> *mut TraceCompiler {
+unsafe extern "C" fn __to_tracedtest_tracecompiler_default() -> *mut TraceCompiler {
     let tc = Box::new(TraceCompiler::new(Default::default(), Default::default()));
     Box::into_raw(tc)
 }
 
 /// Drop a TraceCompiler.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tracecompiler_drop(comp: *mut c_void) {
+unsafe extern "C" fn __to_tracedtest_tracecompiler_drop(comp: *mut c_void) {
     Box::from_raw(comp as *mut TraceCompiler);
 }
 
 /// Inserts a local declaration of the specified TypeId into a TraceCompiler.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tracecompiler_insert_decl(
+unsafe extern "C" fn __to_tracedtest_tracecompiler_insert_decl(
     tc: *mut c_void,
     local: Local,
     local_ty: TypeId,
@@ -90,7 +92,7 @@ unsafe extern "C" fn __ykshimtest_tracecompiler_insert_decl(
 
 /// Returns a string describing the register allocation of the specified local.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tracecompiler_local_to_location_str(
+unsafe extern "C" fn __to_tracedtest_tracecompiler_local_to_location_str(
     tc: *mut c_void,
     local: Local,
 ) -> *mut c_char {
@@ -101,21 +103,24 @@ unsafe extern "C" fn __ykshimtest_tracecompiler_local_to_location_str(
 
 /// Inform a TraceCompiler's register allocator that a local variable is dead.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_tracecompiler_local_dead(tc: *mut TraceCompiler, local: Local) {
+unsafe extern "C" fn __to_tracedtest_tracecompiler_local_dead(
+    tc: *mut TraceCompiler,
+    local: Local,
+) {
     let tc = &mut *tc;
     tc.local_dead(&local).unwrap();
 }
 
 /// Find a symbol's address in the current memory image. Returns NULL if it can't be found.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_find_symbol(sym: *const c_char) -> *mut c_void {
+unsafe extern "C" fn __to_tracedtest_find_symbol(sym: *const c_char) -> *mut c_void {
     find_symbol(CStr::from_ptr(sym).to_str().unwrap()).unwrap_or_else(|_| ptr::null_mut())
 }
 
 /// Interpret a SIR body with the specified interpreter context.
 #[no_mangle]
 #[cfg(feature = "testing")]
-unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *const c_char, ctx: *mut u8) {
+unsafe extern "C" fn __to_tracedtest_interpret_body(body_name: *const c_char, ctx: *mut u8) {
     let fname = CStr::from_ptr(body_name).to_str().unwrap().to_string();
     let mut si = StopgapInterpreter::from_symbol(fname);
     si.set_interp_ctx(ctx);
@@ -124,14 +129,14 @@ unsafe extern "C" fn __ykshimtest_interpret_body(body_name: *const c_char, ctx: 
 
 /// Returns the size of the register allocators register pool.
 #[no_mangle]
-unsafe extern "C" fn __ykshimtest_reg_pool_size() -> usize {
+unsafe extern "C" fn __to_tracedtest_reg_pool_size() -> usize {
     REG_POOL.len()
 }
 
 /// Consumes and compiles the given TIR trace to native code, returning an opaque pointer to the
 /// compiled trace.
 #[no_mangle]
-fn __ykshimtest_compile_tir_trace(tir_trace: *mut TirTrace) -> *mut CompiledTrace {
+fn __to_tracedtest_compile_tir_trace(tir_trace: *mut TirTrace) -> *mut CompiledTrace {
     let tir_trace = unsafe { Box::from_raw(tir_trace) };
     let compiled_trace = ykcompile::compile_trace(*tir_trace);
     Box::into_raw(Box::new(compiled_trace))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,7 @@ impl Workspace {
 }
 
 fn run_action(workspace: Workspace, target: &str, extra_args: &[String], features: &[String]) {
-    // The traced workspace depends on libykshim.so produced by the untraced workspace
+    // The traced workspace depends on libto_traced.so produced by the untraced workspace
     if workspace == Workspace::Traced {
         run_action(Workspace::Untraced, target, extra_args, &[]);
     }
@@ -87,7 +87,7 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String], feature
                 fs.push(format!("yktrace/trace_{}", tracing_kind));
                 cmd.arg(fs.join(","));
 
-                // `cargo test` in the untraced workspace won't build libykshim.so, so we have
+                // `cargo test` in the untraced workspace won't build libto_traced.so, so we have
                 // to force-build it to avoid linkage problems for the traced workspace.
                 if target == "test" || target == "bench" {
                     // Since we are running a different target to what the user requested, the


### PR DESCRIPTION
This PR renames:

  * `ykshim` to `to_traced`
  * `ykshim_client` to `traced_api`

This is mostly a `srep` job -- there are no remaining references to `shim` in the codebase.