### PR TITLE
Add a job queueing system to cap the number of worker threads

### DIFF
--- a/traced/ykrt/Cargo.toml
+++ b/traced/ykrt/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
+num_cpus = "1"
 parking_lot = "0.11"
 parking_lot_core = "0.8"
 strum = { version = "0.20", features = ["derive"] }


### PR DESCRIPTION
Previously yk could spin up an arbitrary number of compilation threads, bounded only by how many loops are present in the end users program. For more complex compilation jobs -- particularly for multi-threaded programs -- we would probably end up making the system grind to a near-halt as we would spend nearly all our time bouncing between partially complete compilation threads, while interpreter threads make very little progress.

This PR adds the concept of "worker threads" (where "compilation" is our only current form of "worker") and bounds their number. A global queue is used when there is more work to be done than threads. When there is no work to be done, threads block without consuming CPU time. A "job" is a `Send`able function (this is a very obvious design in retrospect, but it took me 3 attempts to realise this is the right model for us).

The PR isn't huge, but I've kept it as a small, complete, commits as I think that's easier to understand. https://github.com/softdevteam/yk/commit/669a0a00f4b86299e7eff41a9e72f5916f67ecb7 adds the necessary config bits but does nothing with them. https://github.com/softdevteam/yk/commit/6af51af484f2c3b69212159dad5eaa6977a4c2db adds a basic queue but allows worker threads to spin endlessly when there is no work to do. Those two commits use `std::sync::Mutex` because our use of `catch_unwind` prevents us using `parking_lot`: when I realised that I couldn't even use `std::sync::CondVar` it became clear that `catch_unwind` is not worth the bother so... off with its head (https://github.com/softdevteam/yk/commit/432d456c867bf85e9d2eea2f3ae5f774a8f1b946)! The final major commit uses parking_lot's `Condvar` to ensure that worker threads block gracefully when there is no work for them to do (https://github.com/softdevteam/yk/commit/b3c483dcb0817efd121ed4f613db881c3d3f8090).

That might sound frightening, but the core part of the PR is perhaps 50LoC: the remainder is roughly evenly split between configuration and testing code.