### PR TITLE
ykpack tidy

### DIFF
--- a/untraced/to_traced/src/test_api.rs
+++ b/untraced/to_traced/src/test_api.rs
@@ -55,7 +55,7 @@ unsafe extern "C" fn __to_tracedtest_tirtrace_display<'a, 'm>(
 unsafe extern "C" fn __to_tracedtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId) {
     let sym = CStr::from_ptr(sym);
     let rv = usize::try_from(sir::RETURN_LOCAL.0).unwrap();
-    let tyid = SIR.body(&sym.to_str().unwrap()).unwrap().local_decls[rv].ty;
+    let tyid = SIR.body(&sym.to_str().unwrap()).unwrap().local_decls[rv].ty();
     *ret_tyid = tyid;
 }
 
@@ -81,13 +81,8 @@ unsafe extern "C" fn __to_tracedtest_tracecompiler_insert_decl(
     referenced: bool,
 ) {
     let tc = &mut *(tc as *mut TraceCompiler);
-    tc.local_decls.insert(
-        local,
-        LocalDecl {
-            ty: local_ty,
-            referenced,
-        },
-    );
+    tc.local_decls
+        .insert(local, LocalDecl::new(local_ty, referenced));
 }
 
 /// Returns a string describing the register allocation of the specified local.

--- a/untraced/ykcompile/src/arch/x86_64/mod.rs
+++ b/untraced/ykcompile/src/arch/x86_64/mod.rs
@@ -444,8 +444,8 @@ impl TraceCompiler {
         match ip {
             IRPlace::Val { local, off, .. } => self.local_to_location(*local).offset(*off),
             IRPlace::Indirect { ptr, off, .. } => self
-                .local_to_location(ptr.local)
-                .offset(ptr.off)
+                .local_to_location(ptr.local())
+                .offset(ptr.off())
                 .to_indirect()
                 .offset(*off),
             IRPlace::Const { val, ty } => Location::Const {

--- a/untraced/ykcompile/src/arch/x86_64/mod.rs
+++ b/untraced/ykcompile/src/arch/x86_64/mod.rs
@@ -788,7 +788,7 @@ impl TraceCompiler {
             let dst_ro = dst_loc.unwrap_mem();
             let sir_ty = SIR.ty(&dst.ty());
             let tty = sir_ty.unwrap_tuple();
-            let flag_off = tty.fields.offset(1);
+            let flag_off = tty.fields().offset(1);
 
             if opnd1_ty.is_signed_int() {
                 dynasm!(self.asm

--- a/untraced/ykcompile/src/arch/x86_64/mod.rs
+++ b/untraced/ykcompile/src/arch/x86_64/mod.rs
@@ -788,7 +788,7 @@ impl TraceCompiler {
             let dst_ro = dst_loc.unwrap_mem();
             let sir_ty = SIR.ty(&dst.ty());
             let tty = sir_ty.unwrap_tuple();
-            let flag_off = tty.fields.offsets[1];
+            let flag_off = tty.fields.offset(1);
 
             if opnd1_ty.is_signed_int() {
                 dynasm!(self.asm

--- a/untraced/ykcompile/src/arch/x86_64/store.rs
+++ b/untraced/ykcompile/src/arch/x86_64/store.rs
@@ -15,7 +15,7 @@ impl TraceCompiler {
     }
 
     /// Stores src_loc into dst_loc.
-    pub(super) fn store_raw(&mut self, dst_loc: &Location, src_loc: &Location, size: u64) {
+    pub(super) fn store_raw(&mut self, dst_loc: &Location, src_loc: &Location, size: usize) {
         // This is the one place in the compiler where we allow an explosion of cases over the
         // variants of `Location`. If elsewhere you find yourself matching over a pair of locations
         // you should try and re-work you code so it calls this.

--- a/untraced/ykcompile/src/stack_builder.rs
+++ b/untraced/ykcompile/src/stack_builder.rs
@@ -13,26 +13,26 @@ use std::convert::{TryFrom, TryInto};
 #[derive(Default, Debug)]
 pub(super) struct StackBuilder {
     /// Keeps track of how many bytes have been allocated.
-    stack_top: u64,
+    stack_top: usize,
 }
 
 impl StackBuilder {
     /// Allocate an object of given size and alignment on the stack, returning a `Location::Mem`
     /// describing the position of the allocation. The stack is assumed to grow down.
-    pub(super) fn alloc(&mut self, size: u64, align: u64) -> Location {
+    pub(super) fn alloc(&mut self, size: usize, align: usize) -> Location {
         self.align(align);
         self.stack_top += size;
         Location::new_mem(RBP.code(), -i32::try_from(self.stack_top).unwrap())
     }
 
     /// Aligns `offset` to `align` bytes.
-    fn align(&mut self, align: u64) {
+    fn align(&mut self, align: usize) {
         let mask = align - 1;
         self.stack_top = (self.stack_top + mask) & !mask
     }
 
     /// Total allocated stack size in bytes.
-    pub(super) fn size(&self) -> u32 {
+    pub(super) fn size(&self) -> usize {
         self.stack_top.try_into().unwrap()
     }
 }

--- a/untraced/ykpack/src/build.rs
+++ b/untraced/ykpack/src/build.rs
@@ -56,13 +56,7 @@ impl SirBuilder {
     pub fn new(symbol_name: String, flags: BodyFlags, num_args: usize, block_count: usize) -> Self {
         // Since there's a one-to-one mapping between MIR and SIR blocks, we know how many SIR
         // blocks we will need and can allocate empty SIR blocks ahead of time.
-        let blocks = vec![
-            BasicBlock {
-                stmts: Default::default(),
-                term: Terminator::Unreachable,
-            };
-            block_count
-        ];
+        let blocks = vec![BasicBlock::new(Vec::new(), Terminator::Unreachable); block_count];
 
         Self {
             func: Body {
@@ -104,13 +98,13 @@ impl SirBuilder {
     /// Appends a statement to the specified basic block.
     pub fn push_stmt(&mut self, bb: BasicBlockIndex, stmt: Statement) {
         self.func.blocks[usize::try_from(bb).unwrap()]
-            .stmts
+            .stmts_mut()
             .push(stmt);
     }
 
     /// Sets the terminator of the specified block.
     pub fn set_terminator(&mut self, bb: BasicBlockIndex, new_term: Terminator) {
-        let term = &mut self.func.blocks[usize::try_from(bb).unwrap()].term;
+        let term = self.func.blocks[usize::try_from(bb).unwrap()].term_mut();
         // We should only ever replace the default unreachable terminator assigned at allocation time.
         debug_assert!(*term == Terminator::Unreachable);
         *term = new_term

--- a/untraced/ykpack/src/build.rs
+++ b/untraced/ykpack/src/build.rs
@@ -80,10 +80,7 @@ impl SirBuilder {
     /// Returns a zero-offset IRPlace for a new SIR local.
     pub fn new_sir_local(&mut self, sirty: TypeId) -> IRPlace {
         let idx = u32::try_from(self.func.local_decls.len()).unwrap();
-        self.func.local_decls.push(LocalDecl {
-            ty: sirty,
-            referenced: false,
-        });
+        self.func.local_decls.push(LocalDecl::new(sirty, false));
         IRPlace::Val {
             local: Local(idx),
             off: 0,
@@ -96,7 +93,7 @@ impl SirBuilder {
     pub fn notify_referenced(&mut self, l: Local) {
         let idx = usize::try_from(l.0).unwrap();
         let slot = self.func.local_decls.get_mut(idx).unwrap();
-        slot.referenced = true;
+        slot.set_is_referenced(true);
     }
 
     /// Returns true if there are no basic blocks.

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -283,7 +283,17 @@ impl Display for TupleTy {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
 pub struct StructTy {
     /// The fields of the struct.
-    pub fields: Fields,
+    fields: Fields,
+}
+
+impl StructTy {
+    pub fn new(fields: Fields) -> Self {
+        Self { fields }
+    }
+
+    pub fn fields(&self) -> &Fields {
+        &self.fields
+    }
 }
 
 impl Display for StructTy {

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -329,15 +329,27 @@ bitflags! {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[repr(C)]
 pub struct LocalDecl {
-    pub ty: TypeId,
+    ty: TypeId,
     /// If true this local variable is at some point referenced, and thus should be allocated on
     /// the stack and never in a register.
-    pub referenced: bool,
+    is_referenced: bool,
 }
 
 impl LocalDecl {
-    pub fn new(ty: TypeId, referenced: bool) -> Self {
-        Self { ty, referenced }
+    pub fn new(ty: TypeId, is_referenced: bool) -> Self {
+        Self { ty, is_referenced }
+    }
+
+    pub fn ty(&self) -> TypeId {
+        self.ty
+    }
+
+    pub fn is_referenced(&self) -> bool {
+        self.is_referenced
+    }
+
+    pub fn set_is_referenced(&mut self, is_referenced: bool) {
+        self.is_referenced = is_referenced;
     }
 }
 

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -434,8 +434,22 @@ impl Display for BasicBlock {
 /// Represents a pointer to be dereferenced at runtime.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Ptr {
-    pub local: Local,
-    pub off: OffT,
+    local: Local,
+    off: OffT,
+}
+
+impl Ptr {
+    pub fn new(local: Local, off: OffT) -> Self {
+        Self { local, off }
+    }
+
+    pub fn local(&self) -> Local {
+        self.local
+    }
+
+    pub fn off(&self) -> OffT {
+        self.off
+    }
 }
 
 impl Display for Ptr {

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -90,23 +90,6 @@ pub struct Ty {
     pub kind: TyKind,
 }
 
-impl Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
-            TyKind::SignedInt(si) => write!(f, "{}", si),
-            TyKind::UnsignedInt(ui) => write!(f, "{}", ui),
-            TyKind::Struct(sty) => write!(f, "{}", sty),
-            TyKind::Tuple(tty) => write!(f, "{}", tty),
-            TyKind::Array { elem_ty, len, .. } => write!(f, "[{}; {}]", elem_ty, len),
-            TyKind::Slice(sty) => write!(f, "&[{:?}]", sty),
-            TyKind::Ref(rty) => write!(f, "&{:?}", rty),
-            TyKind::Bool => write!(f, "bool"),
-            TyKind::Char => write!(f, "char"),
-            TyKind::Unimplemented(m) => write!(f, "Unimplemented: {}", m),
-        }
-    }
-}
-
 impl Ty {
     pub fn size(&self) -> u64 {
         u64::try_from(self.size).unwrap()
@@ -142,6 +125,23 @@ impl Ty {
             &tty
         } else {
             panic!("tried to unwrap a non-tuple");
+        }
+    }
+}
+
+impl Display for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            TyKind::SignedInt(si) => write!(f, "{}", si),
+            TyKind::UnsignedInt(ui) => write!(f, "{}", ui),
+            TyKind::Struct(sty) => write!(f, "{}", sty),
+            TyKind::Tuple(tty) => write!(f, "{}", tty),
+            TyKind::Array { elem_ty, len, .. } => write!(f, "[{}; {}]", elem_ty, len),
+            TyKind::Slice(sty) => write!(f, "&[{:?}]", sty),
+            TyKind::Ref(rty) => write!(f, "&{:?}", rty),
+            TyKind::Bool => write!(f, "bool"),
+            TyKind::Char => write!(f, "char"),
+            TyKind::Unimplemented(m) => write!(f, "Unimplemented: {}", m),
         }
     }
 }

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -4,7 +4,6 @@ use bitflags::bitflags;
 use fxhash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::{
-    convert::TryFrom,
     default::Default,
     fmt::{self, Display},
 };
@@ -85,18 +84,26 @@ pub enum TyKind {
 /// The type of a local variable.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
 pub struct Ty {
-    pub size: usize,
-    pub align: usize,
-    pub kind: TyKind,
+    size: usize,
+    align: usize,
+    kind: TyKind,
 }
 
 impl Ty {
-    pub fn size(&self) -> u64 {
-        u64::try_from(self.size).unwrap()
+    pub fn new(size: usize, align: usize, kind: TyKind) -> Self {
+        Ty { size, align, kind }
     }
 
-    pub fn align(&self) -> u64 {
-        u64::try_from(self.align).unwrap()
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn align(&self) -> usize {
+        self.align
+    }
+
+    pub fn kind(&self) -> &TyKind {
+        &self.kind
     }
 
     pub fn is_signed_int(&self) -> bool {

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -218,9 +218,21 @@ impl Display for UnsignedIntTy {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
 pub struct Fields {
     /// Field offsets.
-    pub offsets: Vec<OffT>,
+    offsets: Vec<OffT>,
     /// The type of each field.
-    pub tys: Vec<TypeId>,
+    tys: Vec<TypeId>,
+}
+
+impl Fields {
+    pub fn new(mut offsets: Vec<OffT>, mut tys: Vec<TypeId>) -> Self {
+        offsets.shrink_to_fit();
+        tys.shrink_to_fit();
+        Self { offsets, tys }
+    }
+
+    pub fn offset(&self, idx: usize) -> OffT {
+        self.offsets[idx]
+    }
 }
 
 impl Display for Fields {

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -257,12 +257,20 @@ impl Display for Fields {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
 pub struct TupleTy {
     /// The fields of the tuple.
-    pub fields: Fields,
+    fields: Fields,
 }
 
 impl TupleTy {
+    pub fn new(fields: Fields) -> Self {
+        Self { fields }
+    }
+
     fn is_unit(&self) -> bool {
         self.fields.offsets.is_empty()
+    }
+
+    pub fn fields(&self) -> &Fields {
+        &self.fields
     }
 }
 

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -57,14 +57,6 @@ impl Display for TypeId {
     }
 }
 
-/// The type of a local variable.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
-pub struct Ty {
-    pub size: usize,
-    pub align: usize,
-    pub kind: TyKind,
-}
-
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum TyKind {
     /// Signed integers.
@@ -88,6 +80,14 @@ pub enum TyKind {
     Char,
     /// Anything that we've not yet defined a lowering for.
     Unimplemented(String),
+}
+
+/// The type of a local variable.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
+pub struct Ty {
+    pub size: usize,
+    pub align: usize,
+    pub kind: TyKind,
 }
 
 impl Display for Ty {

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -396,13 +396,29 @@ impl Display for Body {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct BasicBlock {
-    pub stmts: Vec<Statement>,
-    pub term: Terminator,
+    stmts: Vec<Statement>,
+    term: Terminator,
 }
 
 impl BasicBlock {
     pub fn new(stmts: Vec<Statement>, term: Terminator) -> Self {
         Self { stmts, term }
+    }
+
+    pub fn stmts(&self) -> &Vec<Statement> {
+        &self.stmts
+    }
+
+    pub fn stmts_mut(&mut self) -> &mut Vec<Statement> {
+        &mut self.stmts
+    }
+
+    pub fn term(&self) -> &Terminator {
+        &self.term
+    }
+
+    pub fn term_mut(&mut self) -> &mut Terminator {
+        &mut self.term
     }
 }
 

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -157,7 +157,7 @@ macro_rules! make_binop {
                 // Write overflow result into result tuple.
                 let ty = SIR.ty(&dst.ty());
                 let tty = ty.unwrap_tuple();
-                let flag_off = isize::try_from(tty.fields.offset(1)).unwrap();
+                let flag_off = isize::try_from(tty.fields().offset(1)).unwrap();
                 unsafe {
                     std::ptr::write::<u8>(ptr.offset(flag_off), u8::from(of));
                 }

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -409,7 +409,7 @@ impl StopgapInterpreter {
             return val;
         }
         let ptr = self.locals().irplace_to_ptr(src);
-        match &SIR.ty(&src.ty()).kind {
+        match &SIR.ty(&src.ty()).kind() {
             TyKind::UnsignedInt(ui) => match ui {
                 UnsignedIntTy::Usize => todo!(),
                 UnsignedIntTy::U8 => unsafe { u128::from(std::ptr::read::<u8>(ptr)) },
@@ -460,7 +460,7 @@ impl StopgapInterpreter {
             todo!("binops for non-integers");
         }
 
-        match &ty.kind {
+        match &ty.kind() {
             TyKind::UnsignedInt(ui) => match ui {
                 UnsignedIntTy::U8 => self.binop_u8(dst, op, opnd1, opnd2, checked),
                 UnsignedIntTy::U16 => todo!(),

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -157,7 +157,7 @@ macro_rules! make_binop {
                 // Write overflow result into result tuple.
                 let ty = SIR.ty(&dst.ty());
                 let tty = ty.unwrap_tuple();
-                let flag_off = isize::try_from(tty.fields.offsets[1]).unwrap();
+                let flag_off = isize::try_from(tty.fields.offset(1)).unwrap();
                 unsafe {
                     std::ptr::write::<u8>(ptr.offset(flag_off), u8::from(of));
                 }

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -233,7 +233,7 @@ impl StopgapInterpreter {
         let body = frame.body.clone();
         let bbidx = usize::try_from(frame.bbidx).unwrap();
         unsafe {
-            sg.terminator(&body.blocks[bbidx].term);
+            sg.terminator(&body.blocks[bbidx].term());
         }
         sg
     }
@@ -285,7 +285,7 @@ impl StopgapInterpreter {
         while let Some(frame) = self.frames.last() {
             let body = frame.body.clone();
             let block = &body.blocks[usize::try_from(frame.bbidx).unwrap()];
-            for stmt in block.stmts.iter() {
+            for stmt in block.stmts().iter() {
                 match stmt {
                     Statement::MkRef(dst, src) => self.mkref(&dst, &src),
                     Statement::DynOffs { .. } => todo!(),
@@ -306,7 +306,7 @@ impl StopgapInterpreter {
                     }
                 }
             }
-            self.terminator(&block.term);
+            self.terminator(block.term());
         }
         self.rv
     }
@@ -338,7 +338,7 @@ impl StopgapInterpreter {
                     let body = &curframe.body;
                     // Check the previous frame's call terminator to find out where we have to go
                     // next.
-                    let (dst, bbidx) = match &body.blocks[bbidx].term {
+                    let (dst, bbidx) = match body.blocks[bbidx].term() {
                         Terminator::Call {
                             operand: _,
                             args: _,

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -118,12 +118,12 @@ impl LocalMem {
             }
             IRPlace::Indirect { ptr, off, ty: _ty } => {
                 // Get a pointer to the Indirect, which itself points to another pointer.
-                let dst_ptr = self.local_ptr(&ptr.local) as *mut *mut u8;
+                let dst_ptr = self.local_ptr(&ptr.local()) as *mut *mut u8;
                 unsafe {
                     // Dereference the pointer, by reading its value.
                     let mut p = std::ptr::read::<*mut u8>(dst_ptr);
                     // Add the offsets of the Indirect.
-                    p = p.offset(isize::try_from(ptr.off).unwrap());
+                    p = p.offset(isize::try_from(ptr.off()).unwrap());
                     p.offset(isize::try_from(*off).unwrap())
                 }
             }

--- a/untraced/yktrace/src/tir.rs
+++ b/untraced/yktrace/src/tir.rs
@@ -91,7 +91,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
             // times it is called and returned from and only stop ignoring things until we return
             // from the outer-most `do_not_trace` function.
             if let Some(sym) = &dnt_func {
-                match &body.blocks[user_bb_idx_usize].term {
+                match body.blocks[user_bb_idx_usize].term() {
                     Terminator::Return => {
                         if sym == loc.symbol_name {
                             dnt_count -= 1;
@@ -137,7 +137,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                 // number of assigned variables in the functions outer context. For example, if a
                 // function `bar` is inlined into a function `foo`, and `foo` used 5 variables, then
                 // all variables in `bar` are offset by 5.
-                for stmt in body.blocks[user_bb_idx_usize].stmts.iter() {
+                for stmt in body.blocks[user_bb_idx_usize].stmts().iter() {
                     let op = match stmt {
                         Statement::MkRef(dst, src) => Statement::MkRef(
                             rnm.rename_irplace(dst, &body),
@@ -237,7 +237,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                 operand: op,
                 args: _,
                 destination: _,
-            } = &body.blocks[user_bb_idx_usize].term
+            } = body.blocks[user_bb_idx_usize].term()
             {
                 if let Some(callee_sym) = op.symbol() {
                     if let Some(callee_body) = sir.body(callee_sym) {
@@ -264,7 +264,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
 
             // Each SIR terminator becomes zero or more TIR statements.
             let mut term_stmts = Vec::new();
-            match &body.blocks[user_bb_idx_usize].term {
+            match body.blocks[user_bb_idx_usize].term() {
                 Terminator::Call {
                     operand: op,
                     args,
@@ -368,7 +368,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
             }
 
             // Convert the block terminator to a guard if necessary.
-            let guard = match body.blocks[user_bb_idx_usize].term {
+            let guard = match body.blocks[user_bb_idx_usize].term() {
                 Terminator::Goto(_)
                 | Terminator::Return
                 | Terminator::Drop { .. }
@@ -394,7 +394,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                             live_locals: Vec::new(),
                         }),
                         None => {
-                            debug_assert!(next_blk == otherwise_bb);
+                            debug_assert!(next_blk == *otherwise_bb);
                             Some(Guard {
                                 val: rnm.rename_irplace(discr, &body),
                                 kind: GuardKind::OtherInteger(values.to_vec()),

--- a/untraced/yktrace/src/tir.rs
+++ b/untraced/yktrace/src/tir.rs
@@ -539,10 +539,7 @@ impl VarRenamer {
                 ty: *ty,
             },
             IRPlace::Indirect { ptr, off, ty } => IRPlace::Indirect {
-                ptr: Ptr {
-                    local: self.rename_local(&ptr.local, body),
-                    off: ptr.off,
-                },
+                ptr: Ptr::new(self.rename_local(&ptr.local(), body), ptr.off()),
                 off: *off,
                 ty: *ty,
             },

--- a/untraced/yktrace/src/tir.rs
+++ b/untraced/yktrace/src/tir.rs
@@ -224,7 +224,7 @@ impl<'a, 'm> TirTrace<'a, 'm> {
                         _,
                     ) = op
                     {
-                        debug_assert!(sir.ty(&rnm.local_decls[&sir::RETURN_LOCAL].ty).is_bool());
+                        debug_assert!(sir.ty(&rnm.local_decls[&sir::RETURN_LOCAL].ty()).is_bool());
                         continue;
                     }
 
@@ -577,7 +577,7 @@ impl Display for TirTrace<'_, '_> {
             .collect::<Vec<(&Local, &LocalDecl)>>();
         sort_decls.sort_by(|l, r| l.0.partial_cmp(r.0).unwrap());
         for (l, dcl) in sort_decls {
-            writeln!(f, "  {}: {} => {}", l, dcl.ty, self.sir.ty(&dcl.ty))?;
+            writeln!(f, "  {}: {} => {}", l, dcl.ty(), self.sir.ty(&dcl.ty()))?;
         }
 
         writeln!(f, "ops:")?;


### PR DESCRIPTION
This is a mostly-shallow tidy-up of ykpack::types, mostly adding constructors, and adding methods instead of having code access attribute directly. The main aim here is to make it a bit easier to change internal representations in the future. https://github.com/softdevteam/yk/commit/b95a75b614cc720033f497c4de721c3a2a5dbfe4 is a little example of how this can help.

This PR raises one interesting possibility: at the moment `CguHash` is a `u64`. If we convert that to a `u32`, it leads to a saving of 5-10% in the size of the serialised output from ykpack across a `yk` build. That does raise a few more issues than I want to think about in this PR, however.

Note that merging should happen via https://github.com/softdevteam/ykrustc/pull/179.