### PR TITLE
Remove opt-level hacks from cargo configs.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,2 @@
 [alias]
 xtask = "run --package xtask --"
-
-# Although we will never trace the build system, ykrustc will refuse to build it with
-# `-C tracer=hw` and with optimisations enabled.
-[profile.release]
-opt-level = 0
-
-[profile.bench]
-opt-level = 0

--- a/traced/.cargo/config.toml
+++ b/traced/.cargo/config.toml
@@ -1,6 +1,0 @@
-# FIXME for software tracing we could optimise.
-[profile.release]
-opt-level = 0
-
-[profile.bench]
-opt-level = 0

--- a/untraced/.cargo/config.toml
+++ b/untraced/.cargo/config.toml
@@ -1,9 +1,0 @@
-# Cargo will walk up the filesystem and find the cargo config at ../.cargo/config which disables
-# optimisation. We don't want that for the untraced workspace, so we force the opt-levels back
-# to their default values.
-
-[profile.release]
-opt-level = 3
-
-[profile.bench]
-opt-level = 3


### PR DESCRIPTION
Requires https://github.com/softdevteam/ykrustc/pull/180/ to be merged first.

Now that ykrustc automatically turns off optimisation for hardware
tracing, we can simplify our build system a little.

