### PR TITLE
Rename the modules that connect the traced and untraced workspaces.

### DIFF
--- a/traced/Cargo.toml
+++ b/traced/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "untraced_api",
+    "to_untraced",
     "tests",
     "ykrt",
 ]

--- a/traced/tests/Cargo.toml
+++ b/traced/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 fm = "0.2.0"
-untraced_api = { path = "../untraced_api", features=["testing"] }
+to_untraced = { path = "../to_untraced", features=["testing"] }
 libc = "0.2.82"
 paste = "1.0"
 regex = "1.4.3"

--- a/traced/tests/build.rs
+++ b/traced/tests/build.rs
@@ -11,5 +11,5 @@ fn main() {
         env::current_dir().unwrap().to_str().unwrap(),
         profile
     );
-    println!("cargo:rustc-link-lib=dylib=to_traced");
+    println!("cargo:rustc-link-lib=dylib=untraced_api");
 }

--- a/traced/tests/src/codegen/binops.rs
+++ b/traced/tests/src/codegen/binops.rs
@@ -2,7 +2,7 @@
 
 use super::{I16_MAX, I32_MAX, I64_MAX, U16_MAX, U32_MAX, U64_MAX};
 use paste::paste;
-use untraced_api::{compile_trace, start_tracing, TracingKind};
+use to_untraced::{compile_trace, start_tracing, TracingKind};
 
 /// Generates a test for a binary operation.
 macro_rules! mk_binop_test {

--- a/traced/tests/src/codegen/cond_brs.rs
+++ b/traced/tests/src/codegen/cond_brs.rs
@@ -5,7 +5,7 @@ use super::{
     U32_MAX, U32_MIN, U64_MAX, U64_MIN, U8_MAX, U8_MIN,
 };
 use paste::paste;
-use untraced_api::{compile_trace, start_tracing, TracingKind};
+use to_untraced::{compile_trace, start_tracing, TracingKind};
 
 /// Generates a test for a binary operation.
 macro_rules! mk_cond_br_tests {

--- a/traced/tests/src/codegen/mod.rs
+++ b/traced/tests/src/codegen/mod.rs
@@ -3,7 +3,7 @@
 use crate::helpers::{add6, add_some};
 use libc;
 use libc::{abs, getuid};
-use untraced_api::{compile_tir_trace, compile_trace, start_tracing, TirTrace, TracingKind};
+use to_untraced::{compile_tir_trace, compile_trace, start_tracing, TirTrace, TracingKind};
 
 mod binops;
 mod cond_brs;

--- a/traced/tests/src/codegen/reg_alloc.rs
+++ b/traced/tests/src/codegen/reg_alloc.rs
@@ -2,7 +2,7 @@
 
 use crate::helpers::TestTypes;
 use std::{collections::HashMap, convert::TryFrom};
-use untraced_api::{reg_pool_size, Local, LocalDecl, LocalIndex, TraceCompiler};
+use to_untraced::{reg_pool_size, Local, LocalDecl, LocalIndex, TraceCompiler};
 
 // Repeatedly fetching the register for the same local should yield the same register and
 // should not exhaust the allocator.

--- a/traced/tests/src/helpers.rs
+++ b/traced/tests/src/helpers.rs
@@ -2,7 +2,7 @@
 
 use fm::FMBuilder;
 use regex::Regex;
-use untraced_api::{sir_body_ret_ty, TirTrace, TypeId};
+use to_untraced::{sir_body_ret_ty, TirTrace, TypeId};
 
 extern "C" {
     pub(super) fn add6(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64) -> u64;

--- a/traced/tests/src/stopgap/guard_fail.rs
+++ b/traced/tests/src/stopgap/guard_fail.rs
@@ -1,6 +1,6 @@
 //! Testing the stopgap interpreter via guard failures.
 
-use untraced_api::{compile_trace, start_tracing, StopgapInterpreter, TracingKind};
+use to_untraced::{compile_trace, start_tracing, StopgapInterpreter, TracingKind};
 
 #[test]
 fn simple() {

--- a/traced/tests/src/stopgap/interp.rs
+++ b/traced/tests/src/stopgap/interp.rs
@@ -1,6 +1,6 @@
 //! Artificially testing the stopgap interpreter (without a guard failure).
 
-use untraced_api::interpret_body;
+use to_untraced::interpret_body;
 
 #[test]
 fn simple() {

--- a/traced/tests/src/symbols.rs
+++ b/traced/tests/src/symbols.rs
@@ -2,7 +2,7 @@
 
 use libc::{self, c_void};
 use std::ptr;
-use untraced_api::find_symbol;
+use to_untraced::find_symbol;
 
 // Test finding a symbol in a shared object.
 #[test]

--- a/traced/tests/src/tir.rs
+++ b/traced/tests/src/tir.rs
@@ -2,7 +2,7 @@
 
 use crate::helpers::{add6, assert_tir, neg_assert_tir};
 use std::hint::black_box;
-use untraced_api::{start_tracing, TirTrace, TracingKind};
+use to_untraced::{start_tracing, TirTrace, TracingKind};
 use ykrt::trace_debug;
 
 #[test]

--- a/traced/tests/src/tracing.rs
+++ b/traced/tests/src/tracing.rs
@@ -3,7 +3,7 @@
 // FIXME hard-coded hardware testing. Use default mode, but requires more shimming.
 
 use std::{hint::black_box, thread};
-use untraced_api::{start_tracing, TracingKind};
+use to_untraced::{start_tracing, TracingKind};
 
 // Some work to trace.
 #[interp_step]

--- a/traced/to_untraced/Cargo.toml
+++ b/traced/to_untraced/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "untraced_api"
+name = "to_untraced"
 version = "0.1.0"
 authors = ["The Yorick Developers"]
 edition = "2018"

--- a/traced/to_untraced/src/lib.rs
+++ b/traced/to_untraced/src/lib.rs
@@ -1,4 +1,4 @@
-//! Client to the to_traced crate in the untraced workspace.
+//! Client to the untraced_api crate in the untraced workspace.
 //!
 //! For more information, see this section in the documentation:
 //! https://softdevteam.github.io/ykdocs/tech/yk_structure.html
@@ -40,21 +40,22 @@ pub struct Local(pub LocalIndex);
 pub(crate) struct TyIndex(pub(crate) u32);
 
 extern "C" {
-    fn __to_traced_start_tracing(tracing_kind: u8) -> *mut RawThreadTracer;
-    fn __to_traced_stop_tracing(
+    fn __untraced_api_start_tracing(tracing_kind: u8) -> *mut RawThreadTracer;
+    fn __untraced_api_stop_tracing(
         tracer: *mut RawThreadTracer,
         error_msg: *mut *mut c_char,
     ) -> *mut RawSirTrace;
-    fn __to_traced_compile_trace(
+    fn __untraced_api_compile_trace(
         sir_trace: *mut RawSirTrace,
         error_msg: *mut *mut c_char,
     ) -> *mut RawCompiledTrace;
-    fn __to_traced_compiled_trace_get_ptr(compiled_trace: *const RawCompiledTrace)
-        -> *const c_void;
-    fn __to_traced_compiled_trace_drop(compiled_trace: *mut RawCompiledTrace);
-    fn __to_traced_sirtrace_drop(trace: *mut RawSirTrace);
-    fn __to_traced_si_interpret(interp: *mut RawStopgapInterpreter) -> bool;
-    fn __to_traced_sirinterpreter_drop(interp: *mut RawStopgapInterpreter);
+    fn __untraced_api_compiled_trace_get_ptr(
+        compiled_trace: *const RawCompiledTrace,
+    ) -> *const c_void;
+    fn __untraced_api_compiled_trace_drop(compiled_trace: *mut RawCompiledTrace);
+    fn __untraced_api_sirtrace_drop(trace: *mut RawSirTrace);
+    fn __untraced_api_si_interpret(interp: *mut RawStopgapInterpreter) -> bool;
+    fn __untraced_api_sirinterpreter_drop(interp: *mut RawStopgapInterpreter);
 }
 
 /// The different ways by which we can collect a trace.
@@ -71,7 +72,7 @@ pub struct ThreadTracer(*mut RawThreadTracer);
 
 /// Start tracing using the specified kind of tracing.
 pub fn start_tracing(tracing_kind: TracingKind) -> ThreadTracer {
-    let tracer = unsafe { __to_traced_start_tracing(tracing_kind as u8) };
+    let tracer = unsafe { __untraced_api_start_tracing(tracing_kind as u8) };
     debug_assert!(!tracer.is_null());
     ThreadTracer(tracer)
 }
@@ -80,7 +81,7 @@ impl ThreadTracer {
     pub fn stop_tracing(mut self) -> Result<SirTrace, CString> {
         let mut err_msg = std::ptr::null_mut();
         let p = mem::replace(&mut self.0, ptr::null_mut());
-        let sir_trace = unsafe { __to_traced_stop_tracing(p, &mut err_msg) };
+        let sir_trace = unsafe { __untraced_api_stop_tracing(p, &mut err_msg) };
         if sir_trace.is_null() {
             return Err(unsafe { CString::from_raw(err_msg) });
         }
@@ -93,7 +94,7 @@ impl Drop for ThreadTracer {
         if !self.0.is_null() {
             // We are still tracing.
             let mut err_msg = std::ptr::null_mut();
-            unsafe { __to_traced_stop_tracing(self.0, &mut err_msg) };
+            unsafe { __untraced_api_stop_tracing(self.0, &mut err_msg) };
         }
     }
 }
@@ -102,13 +103,13 @@ pub struct StopgapInterpreter(pub *mut RawStopgapInterpreter);
 
 impl StopgapInterpreter {
     pub unsafe fn interpret(&mut self) -> bool {
-        __to_traced_si_interpret(self.0)
+        __untraced_api_si_interpret(self.0)
     }
 }
 
 impl Drop for StopgapInterpreter {
     fn drop(&mut self) {
-        unsafe { __to_traced_sirinterpreter_drop(self.0) }
+        unsafe { __untraced_api_sirinterpreter_drop(self.0) }
     }
 }
 
@@ -120,7 +121,7 @@ unsafe impl Sync for SirTrace {}
 impl Drop for SirTrace {
     fn drop(&mut self) {
         if !self.0.is_null() {
-            unsafe { __to_traced_sirtrace_drop(self.0) }
+            unsafe { __untraced_api_sirtrace_drop(self.0) }
         }
     }
 }
@@ -136,7 +137,7 @@ unsafe impl<I> Sync for CompiledTrace<I> {}
 pub fn compile_trace<T>(mut sir_trace: SirTrace) -> Result<CompiledTrace<T>, CString> {
     let mut err_msg = std::ptr::null_mut();
     let p = mem::replace(&mut sir_trace.0, ptr::null_mut());
-    let compiled = unsafe { __to_traced_compile_trace(p, &mut err_msg) };
+    let compiled = unsafe { __untraced_api_compile_trace(p, &mut err_msg) };
     if compiled.is_null() {
         return Err(unsafe { CString::from_raw(err_msg) });
     }
@@ -148,7 +149,7 @@ pub fn compile_trace<T>(mut sir_trace: SirTrace) -> Result<CompiledTrace<T>, CSt
 
 impl<I> CompiledTrace<I> {
     pub fn ptr(&self) -> *const u8 {
-        unsafe { __to_traced_compiled_trace_get_ptr(self.compiled) as *const u8 }
+        unsafe { __untraced_api_compiled_trace_get_ptr(self.compiled) as *const u8 }
     }
 
     /// Execute the trace with the given interpreter context.
@@ -176,6 +177,6 @@ impl<I> CompiledTrace<I> {
 
 impl<I> Drop for CompiledTrace<I> {
     fn drop(&mut self) {
-        unsafe { __to_traced_compiled_trace_drop(self.compiled) }
+        unsafe { __untraced_api_compiled_trace_drop(self.compiled) }
     }
 }

--- a/traced/to_untraced/src/test_api.rs
+++ b/traced/to_untraced/src/test_api.rs
@@ -1,4 +1,4 @@
-//! The testing API client to to_traced.
+//! The testing interface to untraced_api.
 #![cfg(feature = "testing")]
 
 use crate::{CompiledTrace, Local, RawCompiledTrace, RawSirTrace, RawTirTrace, SirTrace, TyIndex};
@@ -24,29 +24,29 @@ pub struct TypeId {
 }
 
 extern "C" {
-    fn __to_tracedtest_compile_tir_trace(tir_trace: *mut RawTirTrace) -> *mut RawCompiledTrace;
-    fn __to_tracedtest_sirtrace_len(sir_trace: *mut RawSirTrace) -> size_t;
-    fn __to_tracedtest_tirtrace_new(sir_trace: *mut RawSirTrace) -> *mut RawTirTrace;
-    fn __to_traced_tirtrace_drop(tir_trace: *mut RawTirTrace);
-    fn __to_tracedtest_tracecompiler_drop(comp: *mut RawTraceCompiler);
-    fn __to_tracedtest_tirtrace_len(tir_trace: *mut RawTirTrace) -> size_t;
-    fn __to_tracedtest_tirtrace_display(tir_trace: *mut RawTirTrace) -> *mut c_char;
-    fn __to_tracedtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId);
-    fn __to_tracedtest_tracecompiler_default() -> *mut RawTraceCompiler;
-    fn __to_tracedtest_tracecompiler_insert_decl(
+    fn __untraced_apitest_compile_tir_trace(tir_trace: *mut RawTirTrace) -> *mut RawCompiledTrace;
+    fn __untraced_apitest_sirtrace_len(sir_trace: *mut RawSirTrace) -> size_t;
+    fn __untraced_apitest_tirtrace_new(sir_trace: *mut RawSirTrace) -> *mut RawTirTrace;
+    fn __untraced_api_tirtrace_drop(tir_trace: *mut RawTirTrace);
+    fn __untraced_apitest_tracecompiler_drop(comp: *mut RawTraceCompiler);
+    fn __untraced_apitest_tirtrace_len(tir_trace: *mut RawTirTrace) -> size_t;
+    fn __untraced_apitest_tirtrace_display(tir_trace: *mut RawTirTrace) -> *mut c_char;
+    fn __untraced_apitest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId);
+    fn __untraced_apitest_tracecompiler_default() -> *mut RawTraceCompiler;
+    fn __untraced_apitest_tracecompiler_insert_decl(
         tc: *mut RawTraceCompiler,
         local: Local,
         local_ty: TypeId,
         referenced: bool,
     );
-    fn __to_tracedtest_tracecompiler_local_to_location_str(
+    fn __untraced_apitest_tracecompiler_local_to_location_str(
         tc: *mut RawTraceCompiler,
         local: Local,
     ) -> *mut c_char;
-    fn __to_tracedtest_tracecompiler_local_dead(tc: *mut RawTraceCompiler, local: Local);
-    fn __to_tracedtest_find_symbol(sym: *const c_char) -> *mut c_void;
-    fn __to_tracedtest_interpret_body(body_name: *const c_char, ctx: *mut u8);
-    fn __to_tracedtest_reg_pool_size() -> usize;
+    fn __untraced_apitest_tracecompiler_local_dead(tc: *mut RawTraceCompiler, local: Local);
+    fn __untraced_apitest_find_symbol(sym: *const c_char) -> *mut c_void;
+    fn __untraced_apitest_interpret_body(body_name: *const c_char, ctx: *mut u8);
+    fn __untraced_apitest_reg_pool_size() -> usize;
 }
 
 #[derive(Debug)]
@@ -55,7 +55,7 @@ pub struct TirTrace(*mut RawTirTrace);
 
 impl TirTrace {
     pub fn new(sir_trace: &SirTrace) -> Self {
-        Self(unsafe { __to_tracedtest_tirtrace_new(sir_trace.0) })
+        Self(unsafe { __untraced_apitest_tirtrace_new(sir_trace.0) })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -63,21 +63,21 @@ impl TirTrace {
     }
 
     pub fn len(&self) -> usize {
-        unsafe { __to_tracedtest_tirtrace_len(self.0) }
+        unsafe { __untraced_apitest_tirtrace_len(self.0) }
     }
 }
 
 impl Drop for TirTrace {
     fn drop(&mut self) {
         if !self.0.is_null() {
-            unsafe { __to_traced_tirtrace_drop(self.0) };
+            unsafe { __untraced_api_tirtrace_drop(self.0) };
         }
     }
 }
 
 impl fmt::Display for TirTrace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let cstr = unsafe { CString::from_raw(__to_tracedtest_tirtrace_display(self.0)) };
+        let cstr = unsafe { CString::from_raw(__untraced_apitest_tirtrace_display(self.0)) };
         write!(f, "{}", cstr.into_string().unwrap())
     }
 }
@@ -88,7 +88,7 @@ pub fn sir_body_ret_ty(sym: &str) -> TypeId {
         cgu: CguHash(0),
         idx: TyIndex(0),
     };
-    unsafe { __to_tracedtest_body_ret_ty(sym_c.as_ptr(), &mut ret) };
+    unsafe { __untraced_apitest_body_ret_ty(sym_c.as_ptr(), &mut ret) };
     ret
 }
 
@@ -107,27 +107,29 @@ pub struct TraceCompiler(*mut c_void);
 
 impl TraceCompiler {
     pub fn new(local_decls: HashMap<Local, LocalDecl>) -> Self {
-        let tc = unsafe { __to_tracedtest_tracecompiler_default() };
+        let tc = unsafe { __untraced_apitest_tracecompiler_default() };
         for (l, decl) in local_decls.iter() {
-            unsafe { __to_tracedtest_tracecompiler_insert_decl(tc, *l, decl.ty, decl.referenced) };
+            unsafe {
+                __untraced_apitest_tracecompiler_insert_decl(tc, *l, decl.ty, decl.referenced)
+            };
         }
 
         Self(tc)
     }
 
     pub fn local_to_location_str(&mut self, local: Local) -> String {
-        let ptr = unsafe { __to_tracedtest_tracecompiler_local_to_location_str(self.0, local) };
+        let ptr = unsafe { __untraced_apitest_tracecompiler_local_to_location_str(self.0, local) };
         String::from(unsafe { CString::from_raw(ptr).to_str().unwrap() })
     }
 
     pub fn local_dead(&mut self, local: Local) {
-        unsafe { __to_tracedtest_tracecompiler_local_dead(self.0, local) };
+        unsafe { __untraced_apitest_tracecompiler_local_dead(self.0, local) };
     }
 }
 
 impl Drop for TraceCompiler {
     fn drop(&mut self) {
-        unsafe { __to_tracedtest_tracecompiler_drop(self.0) }
+        unsafe { __untraced_apitest_tracecompiler_drop(self.0) }
     }
 }
 
@@ -137,21 +139,21 @@ impl SirTrace {
     }
 
     pub fn len(&self) -> usize {
-        unsafe { __to_tracedtest_sirtrace_len(self.0) }
+        unsafe { __untraced_apitest_sirtrace_len(self.0) }
     }
 }
 
 pub fn interpret_body<I>(body_name: &str, ctx: &mut I) {
     let body_cstr = CString::new(body_name).unwrap();
-    unsafe { __to_tracedtest_interpret_body(body_cstr.as_ptr(), ctx as *mut _ as *mut u8) };
+    unsafe { __untraced_apitest_interpret_body(body_cstr.as_ptr(), ctx as *mut _ as *mut u8) };
 }
 
 pub fn reg_pool_size() -> usize {
-    unsafe { __to_tracedtest_reg_pool_size() }
+    unsafe { __untraced_apitest_reg_pool_size() }
 }
 
 pub fn compile_tir_trace<T>(mut tir_trace: TirTrace) -> Result<CompiledTrace<T>, CString> {
-    let compiled = unsafe { __to_tracedtest_compile_tir_trace(tir_trace.0) };
+    let compiled = unsafe { __untraced_apitest_compile_tir_trace(tir_trace.0) };
     tir_trace.0 = ptr::null_mut(); // consumed.
     Ok(CompiledTrace {
         compiled,
@@ -161,5 +163,5 @@ pub fn compile_tir_trace<T>(mut tir_trace: TirTrace) -> Result<CompiledTrace<T>,
 
 pub fn find_symbol(sym: &str) -> *mut c_void {
     let sym_cstr = CString::new(sym).unwrap();
-    unsafe { __to_tracedtest_find_symbol(sym_cstr.as_ptr()) }
+    unsafe { __untraced_apitest_find_symbol(sym_cstr.as_ptr()) }
 }

--- a/traced/ykrt/Cargo.toml
+++ b/traced/ykrt/Cargo.toml
@@ -10,7 +10,7 @@ num_cpus = "1"
 parking_lot = "0.11"
 parking_lot_core = "0.8"
 strum = { version = "0.20", features = ["derive"] }
-untraced_api = { path = "../untraced_api" }
+to_untraced = { path = "../to_untraced" }
 
 [build-dependencies]
 regex = "1.4.3"

--- a/traced/ykrt/build.rs
+++ b/traced/ykrt/build.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 include!("../../build_aux.rs");
 
-const TO_TRACED_SO: &str = "libto_traced.so";
+const UNTRACED_SO: &str = "libuntraced_api.so";
 
 fn main() {
     let mut untraced_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -23,7 +23,7 @@ fn main() {
         let tracing_kind = find_tracing_kind(&rustflags);
         rustflags = make_untraced_rustflags(&rustflags);
         let mut cmd = Command::new(cargo);
-        cmd.current_dir(untraced_dir.join("to_traced"))
+        cmd.current_dir(untraced_dir.join("untraced_api"))
             .arg("build")
             .arg("--features")
             .arg(format!("yktrace/trace_{}", tracing_kind))
@@ -40,18 +40,18 @@ fn main() {
         }
     }
 
-    // If we symlink libto_traced.so into the target dir, then this is already in the linker path when
+    // If we symlink libuntraced_api.so into the target dir, then this is already in the linker path when
     // run under cargo. In other words, the user won't have to set LD_LIBRARY_PATH.
     let mut sym_dst = PathBuf::from(env::var("OUT_DIR").unwrap());
     sym_dst.push("..");
     sym_dst.push("..");
     sym_dst.push("..");
-    sym_dst.push(TO_TRACED_SO);
+    sym_dst.push(UNTRACED_SO);
     if !PathBuf::from(&sym_dst).exists() {
         let mut sym_src = untraced_dir;
         sym_src.push("target");
         sym_src.push(&profile);
-        sym_src.push(TO_TRACED_SO);
+        sym_src.push(UNTRACED_SO);
         symlink(sym_src, sym_dst).unwrap();
     }
 
@@ -60,5 +60,5 @@ fn main() {
         env::current_dir().unwrap().to_str().unwrap(),
         profile
     );
-    println!("cargo:rustc-link-lib=dylib=to_traced");
+    println!("cargo:rustc-link-lib=dylib=untraced_api");
 }

--- a/traced/ykrt/src/location.rs
+++ b/traced/ykrt/src/location.rs
@@ -15,7 +15,7 @@ use parking_lot_core::{
 };
 use strum::EnumDiscriminants;
 
-use untraced_api::{CompiledTrace, ThreadTracer};
+use to_untraced::{CompiledTrace, ThreadTracer};
 
 use crate::mt::HotThreshold;
 

--- a/traced/ykrt/src/mt.rs
+++ b/traced/ykrt/src/mt.rs
@@ -22,7 +22,7 @@ use parking_lot::{Condvar, Mutex, MutexGuard};
 use parking_lot_core::SpinWait;
 
 use crate::location::{HotLocation, Location, State, ThreadIdInner};
-use untraced_api::{
+use to_untraced::{
     compile_trace, start_tracing, CompiledTrace, RawStopgapInterpreter, SirTrace,
     StopgapInterpreter, TracingKind,
 };

--- a/untraced/Cargo.toml
+++ b/untraced/Cargo.toml
@@ -3,7 +3,7 @@ members = [
     "ykcompile",
     "ykpack",
     "yksg",
-    "to_traced",
+    "untraced_api",
     "yktrace",
     "ykview",
 ]

--- a/untraced/untraced_api/Cargo.toml
+++ b/untraced/untraced_api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "to_traced"
+name = "untraced_api"
 version = "0.1.0"
 authors = ["The Yorick Developers"]
 edition = "2018"

--- a/untraced/untraced_api/src/lib.rs
+++ b/untraced/untraced_api/src/lib.rs
@@ -29,7 +29,7 @@ enum TracingKind {
 /// Starts tracing using the specified kind, returning a ThreadTracer through which to stop
 /// tracing.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_start_tracing(tracing_kind: u8) -> *mut ThreadTracer {
+unsafe extern "C" fn __untraced_api_start_tracing(tracing_kind: u8) -> *mut ThreadTracer {
     let tracing_kind = match tracing_kind {
         0 => yktrace::TracingKind::SoftwareTracing,
         1 => yktrace::TracingKind::HardwareTracing,
@@ -43,7 +43,7 @@ unsafe extern "C" fn __to_traced_start_tracing(tracing_kind: u8) -> *mut ThreadT
 /// error occurs then the returned pointer will be NULL and `error_msg` will contain details of the
 /// error.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_stop_tracing(
+unsafe extern "C" fn __untraced_api_stop_tracing(
     tracer: *mut ThreadTracer,
     error_msg: *mut *mut c_char,
 ) -> *mut SirTrace {
@@ -61,7 +61,7 @@ unsafe extern "C" fn __to_traced_stop_tracing(
 /// Compiles a SIR trace into an opaque pointer to a native code trace. If an error occurs, the
 /// returned pointer will be null, and `error_msg` will contain details of the error.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_compile_trace(
+unsafe extern "C" fn __untraced_api_compile_trace(
     sir_trace: *mut SirTrace,
     error_msg: *mut *mut c_char,
 ) -> *mut CompiledTrace {
@@ -79,7 +79,7 @@ unsafe extern "C" fn __to_traced_compile_trace(
 
 /// Gets a callable function pointer from a compiled trace.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_compiled_trace_get_ptr(
+unsafe extern "C" fn __untraced_api_compiled_trace_get_ptr(
     compiled_trace: *const CompiledTrace,
 ) -> *const c_void {
     let compiled_trace = &*(compiled_trace as *mut CompiledTrace);
@@ -88,30 +88,30 @@ unsafe extern "C" fn __to_traced_compiled_trace_get_ptr(
 
 /// Drop a compiled trace.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_compiled_trace_drop(compiled_trace: *mut CompiledTrace) {
+unsafe extern "C" fn __untraced_api_compiled_trace_drop(compiled_trace: *mut CompiledTrace) {
     Box::from_raw(compiled_trace);
 }
 
 /// Drop a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_sirtrace_drop(trace: *mut SirTrace) {
+unsafe extern "C" fn __untraced_api_sirtrace_drop(trace: *mut SirTrace) {
     Box::from_raw(trace);
 }
 
 /// Drop a TIR trace.
 #[no_mangle]
-unsafe fn __to_traced_tirtrace_drop(tir_trace: *mut TirTrace) {
+unsafe fn __untraced_api_tirtrace_drop(tir_trace: *mut TirTrace) {
     Box::from_raw(tir_trace);
 }
 
 /// Start an initialised StopgapInterpreter.
 #[no_mangle]
-unsafe extern "C" fn __to_traced_si_interpret(si: *mut yksg::StopgapInterpreter) -> bool {
+unsafe extern "C" fn __untraced_api_si_interpret(si: *mut yksg::StopgapInterpreter) -> bool {
     let si = &mut *si;
     si.interpret()
 }
 
 #[no_mangle]
-unsafe extern "C" fn __to_traced_sirinterpreter_drop(interp: *mut yksg::StopgapInterpreter) {
+unsafe extern "C" fn __untraced_api_sirinterpreter_drop(interp: *mut yksg::StopgapInterpreter) {
     Box::from_raw(interp);
 }

--- a/untraced/untraced_api/src/test_api.rs
+++ b/untraced/untraced_api/src/test_api.rs
@@ -1,4 +1,4 @@
-//! The to_traced testing API.
+//! The untraced testing API.
 //!
 //! These functions are only exposed to allow testing from the traced workspace.
 #![cfg(feature = "testing")]
@@ -18,13 +18,13 @@ use yktrace::tir::TirTrace;
 
 /// Returns the length of a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_sirtrace_len(sir_trace: *mut SirTrace) -> size_t {
+unsafe extern "C" fn __untraced_apitest_sirtrace_len(sir_trace: *mut SirTrace) -> size_t {
     (&mut *sir_trace).len()
 }
 
 /// Compile a TIR trace from a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tirtrace_new<'a, 'm>(
+unsafe extern "C" fn __untraced_apitest_tirtrace_new<'a, 'm>(
     sir_trace: *mut SirTrace,
 ) -> *mut TirTrace<'a, 'm> {
     let sir_trace = &mut *(sir_trace);
@@ -33,7 +33,7 @@ unsafe extern "C" fn __to_tracedtest_tirtrace_new<'a, 'm>(
 
 /// Returns the length of a SIR trace.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tirtrace_len<'a, 'm>(
+unsafe extern "C" fn __untraced_apitest_tirtrace_len<'a, 'm>(
     tir_trace: *mut TirTrace<'a, 'm>,
 ) -> size_t {
     (*tir_trace).len()
@@ -41,7 +41,7 @@ unsafe extern "C" fn __to_tracedtest_tirtrace_len<'a, 'm>(
 
 /// Returns the human-readable Display string of a TIR trace.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tirtrace_display<'a, 'm>(
+unsafe extern "C" fn __untraced_apitest_tirtrace_display<'a, 'm>(
     tir_trace: *mut TirTrace<'a, 'm>,
 ) -> *mut c_char {
     let tt = &(*tir_trace);
@@ -52,7 +52,7 @@ unsafe extern "C" fn __to_tracedtest_tirtrace_display<'a, 'm>(
 /// Looks up the TypeId of the return value of the given symbol. The TypeId is returned via the
 /// `ret_tyid` argument.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId) {
+unsafe extern "C" fn __untraced_apitest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId) {
     let sym = CStr::from_ptr(sym);
     let rv = usize::try_from(sir::RETURN_LOCAL.0).unwrap();
     let tyid = SIR.body(&sym.to_str().unwrap()).unwrap().local_decls[rv].ty();
@@ -61,20 +61,20 @@ unsafe extern "C" fn __to_tracedtest_body_ret_ty(sym: *const c_char, ret_tyid: *
 
 /// Creates a TraceCompiler with default settings.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tracecompiler_default() -> *mut TraceCompiler {
+unsafe extern "C" fn __untraced_apitest_tracecompiler_default() -> *mut TraceCompiler {
     let tc = Box::new(TraceCompiler::new(Default::default(), Default::default()));
     Box::into_raw(tc)
 }
 
 /// Drop a TraceCompiler.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tracecompiler_drop(comp: *mut c_void) {
+unsafe extern "C" fn __untraced_apitest_tracecompiler_drop(comp: *mut c_void) {
     Box::from_raw(comp as *mut TraceCompiler);
 }
 
 /// Inserts a local declaration of the specified TypeId into a TraceCompiler.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tracecompiler_insert_decl(
+unsafe extern "C" fn __untraced_apitest_tracecompiler_insert_decl(
     tc: *mut c_void,
     local: Local,
     local_ty: TypeId,
@@ -87,7 +87,7 @@ unsafe extern "C" fn __to_tracedtest_tracecompiler_insert_decl(
 
 /// Returns a string describing the register allocation of the specified local.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tracecompiler_local_to_location_str(
+unsafe extern "C" fn __untraced_apitest_tracecompiler_local_to_location_str(
     tc: *mut c_void,
     local: Local,
 ) -> *mut c_char {
@@ -98,7 +98,7 @@ unsafe extern "C" fn __to_tracedtest_tracecompiler_local_to_location_str(
 
 /// Inform a TraceCompiler's register allocator that a local variable is dead.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_tracecompiler_local_dead(
+unsafe extern "C" fn __untraced_apitest_tracecompiler_local_dead(
     tc: *mut TraceCompiler,
     local: Local,
 ) {
@@ -108,14 +108,14 @@ unsafe extern "C" fn __to_tracedtest_tracecompiler_local_dead(
 
 /// Find a symbol's address in the current memory image. Returns NULL if it can't be found.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_find_symbol(sym: *const c_char) -> *mut c_void {
+unsafe extern "C" fn __untraced_apitest_find_symbol(sym: *const c_char) -> *mut c_void {
     find_symbol(CStr::from_ptr(sym).to_str().unwrap()).unwrap_or_else(|_| ptr::null_mut())
 }
 
 /// Interpret a SIR body with the specified interpreter context.
 #[no_mangle]
 #[cfg(feature = "testing")]
-unsafe extern "C" fn __to_tracedtest_interpret_body(body_name: *const c_char, ctx: *mut u8) {
+unsafe extern "C" fn __untraced_apitest_interpret_body(body_name: *const c_char, ctx: *mut u8) {
     let fname = CStr::from_ptr(body_name).to_str().unwrap().to_string();
     let mut si = StopgapInterpreter::from_symbol(fname);
     si.set_interp_ctx(ctx);
@@ -124,14 +124,14 @@ unsafe extern "C" fn __to_tracedtest_interpret_body(body_name: *const c_char, ct
 
 /// Returns the size of the register allocators register pool.
 #[no_mangle]
-unsafe extern "C" fn __to_tracedtest_reg_pool_size() -> usize {
+unsafe extern "C" fn __untraced_apitest_reg_pool_size() -> usize {
     REG_POOL.len()
 }
 
 /// Consumes and compiles the given TIR trace to native code, returning an opaque pointer to the
 /// compiled trace.
 #[no_mangle]
-fn __to_tracedtest_compile_tir_trace(tir_trace: *mut TirTrace) -> *mut CompiledTrace {
+fn __untraced_apitest_compile_tir_trace(tir_trace: *mut TirTrace) -> *mut CompiledTrace {
     let tir_trace = unsafe { Box::from_raw(tir_trace) };
     let compiled_trace = ykcompile::compile_trace(*tir_trace);
     Box::into_raw(Box::new(compiled_trace))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,7 @@ impl Workspace {
 }
 
 fn run_action(workspace: Workspace, target: &str, extra_args: &[String], features: &[String]) {
-    // The traced workspace depends on libto_traced.so produced by the untraced workspace
+    // The traced workspace depends on libuntraced_api.so produced by the untraced workspace
     if workspace == Workspace::Traced {
         run_action(Workspace::Untraced, target, extra_args, &[]);
     }
@@ -87,7 +87,7 @@ fn run_action(workspace: Workspace, target: &str, extra_args: &[String], feature
                 fs.push(format!("yktrace/trace_{}", tracing_kind));
                 cmd.arg(fs.join(","));
 
-                // `cargo test` in the untraced workspace won't build libto_traced.so, so we have
+                // `cargo test` in the untraced workspace won't build libuntraced_api.so, so we have
                 // to force-build it to avoid linkage problems for the traced workspace.
                 if target == "test" || target == "bench" {
                     // Since we are running a different target to what the user requested, the


### PR DESCRIPTION
to_traced -> untraced_api
untraced_api -> to_traced

So now we have:

```
            Traced Workspace                  Untraced Workspace
+------------------------------------+ +----------------------------------+
| Interpreter +                      | |                                  |
|             |                      | |                                  |
|             +-----> to_untraced +------> untraced_api +---> JIT runtime |
|             |                      | |                                  |
|       Tests +                      | |                                  |
+------------------------------------+ +----------------------------------+
```
