### PR TITLE
Make ykpack::Body's attributes private.

### DIFF
--- a/untraced/untraced_api/src/test_api.rs
+++ b/untraced/untraced_api/src/test_api.rs
@@ -55,7 +55,7 @@ unsafe extern "C" fn __untraced_apitest_tirtrace_display<'a, 'm>(
 unsafe extern "C" fn __untraced_apitest_body_ret_ty(sym: *const c_char, ret_tyid: *mut TypeId) {
     let sym = CStr::from_ptr(sym);
     let rv = usize::try_from(sir::RETURN_LOCAL.0).unwrap();
-    let tyid = SIR.body(&sym.to_str().unwrap()).unwrap().local_decls[rv].ty();
+    let tyid = SIR.body(&sym.to_str().unwrap()).unwrap().local_decls()[rv].ty();
     *ret_tyid = tyid;
 }
 

--- a/untraced/ykcompile/src/arch/x86_64/mod.rs
+++ b/untraced/ykcompile/src/arch/x86_64/mod.rs
@@ -1468,12 +1468,13 @@ impl TraceCompiler {
                 let sym = block.symbol_name;
                 let bbidx = block.bb_idx;
                 let body = SIR.body(sym).unwrap();
+                let layout = body.layout();
                 let sym_label = sym_labels[i];
 
                 // Allocate memory for the live variables.
                 dynasm!(self.asm
-                    ; mov rdi, i32::try_from(body.layout.0).unwrap()
-                    ; mov rsi, i32::try_from(body.layout.1).unwrap()
+                    ; mov rdi, i32::try_from(layout.0).unwrap()
+                    ; mov rsi, i32::try_from(layout.1).unwrap()
                     ; mov r11, QWORD alloc_live_vars as i64
                     ; call r11
                 );
@@ -1481,8 +1482,9 @@ impl TraceCompiler {
                 for liveloc in &guard.live_locals[i] {
                     let ty = self.local_decls[&liveloc.tir].ty();
                     let size = SIR.ty(&ty).size();
-                    let off = i32::try_from(body.offsets[usize::try_from(liveloc.sir.0).unwrap()])
-                        .unwrap();
+                    let off =
+                        i32::try_from(body.offsets()[usize::try_from(liveloc.sir.0).unwrap()])
+                            .unwrap();
                     let dst_loc = Location::Mem(RegAndOffset {
                         reg: RAX.code(),
                         off,

--- a/untraced/ykpack/src/lib.rs
+++ b/untraced/ykpack/src/lib.rs
@@ -58,15 +58,15 @@ mod tests {
             BasicBlock::new(stmts1_b1, dummy_term.clone()),
             BasicBlock::new(stmts1_b2, dummy_term.clone()),
         ];
-        let sir1 = Pack::Body(Body {
-            symbol_name: String::from("symbol1"),
-            blocks: blocks1,
-            flags: BodyFlags::empty(),
-            local_decls: Vec::new(),
-            num_args: 0,
-            layout: (0, 0),
-            offsets: Vec::new(),
-        });
+        let sir1 = Pack::Body(Body::new(
+            String::from("symbol1"),
+            blocks1,
+            BodyFlags::empty(),
+            Vec::new(),
+            0,
+            (0, 0),
+            Vec::new(),
+        ));
 
         let stmts2_b1 = vec![Statement::Nop; 7];
         let stmts2_b2 = vec![Statement::Nop; 200];
@@ -76,15 +76,15 @@ mod tests {
             BasicBlock::new(stmts2_b2, dummy_term.clone()),
             BasicBlock::new(stmts2_b3, dummy_term.clone()),
         ];
-        let sir2 = Pack::Body(Body {
-            symbol_name: String::from("symbol2"),
-            blocks: blocks2,
-            flags: BodyFlags::empty(),
-            local_decls: Vec::new(),
-            num_args: 0,
-            layout: (0, 0),
-            offsets: Vec::new(),
-        });
+        let sir2 = Pack::Body(Body::new(
+            String::from("symbol2"),
+            blocks2,
+            BodyFlags::empty(),
+            Vec::new(),
+            0,
+            (0, 0),
+            Vec::new(),
+        ));
 
         vec![sir1, sir2]
     }

--- a/untraced/ykpack/src/types.rs
+++ b/untraced/ykpack/src/types.rs
@@ -363,13 +363,79 @@ impl Display for LocalDecl {
 /// Each Body maps to exactly one MIR Body.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Body {
-    pub symbol_name: String,
-    pub blocks: Vec<BasicBlock>,
-    pub flags: BodyFlags,
-    pub local_decls: Vec<LocalDecl>,
-    pub(super) num_args: usize,
-    pub layout: (usize, usize),
-    pub offsets: Vec<usize>,
+    symbol_name: String,
+    blocks: Vec<BasicBlock>,
+    flags: BodyFlags,
+    local_decls: Vec<LocalDecl>,
+    num_args: usize,
+    layout: (usize, usize),
+    offsets: Vec<usize>,
+}
+
+impl Body {
+    pub fn new(
+        symbol_name: String,
+        blocks: Vec<BasicBlock>,
+        flags: BodyFlags,
+        local_decls: Vec<LocalDecl>,
+        num_args: usize,
+        layout: (usize, usize),
+        offsets: Vec<usize>,
+    ) -> Self {
+        Self {
+            symbol_name,
+            blocks,
+            flags,
+            local_decls,
+            num_args,
+            layout,
+            offsets,
+        }
+    }
+
+    pub fn symbol_name(&self) -> &String {
+        &self.symbol_name
+    }
+
+    pub fn blocks(&self) -> &Vec<BasicBlock> {
+        &self.blocks
+    }
+
+    pub fn blocks_mut(&mut self) -> &mut Vec<BasicBlock> {
+        &mut self.blocks
+    }
+
+    pub fn flags(&self) -> BodyFlags {
+        self.flags
+    }
+
+    pub fn local_decls(&self) -> &Vec<LocalDecl> {
+        &self.local_decls
+    }
+
+    pub fn local_decls_mut(&mut self) -> &mut Vec<LocalDecl> {
+        &mut self.local_decls
+    }
+
+    pub fn num_args(&self) -> usize {
+        self.num_args
+    }
+
+    pub fn layout(&self) -> (usize, usize) {
+        self.layout
+    }
+
+    pub fn set_layout(&mut self, size: usize, align: usize) {
+        self.layout = (size, align);
+    }
+
+    pub fn offsets(&self) -> &Vec<usize> {
+        &self.offsets
+    }
+
+    pub fn offsets_mut(&mut self) -> &mut Vec<usize> {
+        &mut self.offsets
+    }
 }
 
 impl Display for Body {

--- a/untraced/yktrace/src/sir.rs
+++ b/untraced/yktrace/src/sir.rs
@@ -241,7 +241,7 @@ pub fn sir_trace_str(sir: &Sir, trace: &SirTrace, show_blocks: bool) -> String {
 
         let body = sir.body(&loc.symbol_name);
         if let Some(ref body) = body {
-            if body.flags.contains(BodyFlags::INTERP_STEP) {
+            if body.flags().contains(BodyFlags::INTERP_STEP) {
                 write!(res_r, "INTERP_STEP ").unwrap();
             }
         }
@@ -252,7 +252,7 @@ pub fn sir_trace_str(sir: &Sir, trace: &SirTrace, show_blocks: bool) -> String {
                 writeln!(
                     res_r,
                     "{}:",
-                    body.blocks[usize::try_from(loc.bb_idx).unwrap()]
+                    body.blocks()[usize::try_from(loc.bb_idx).unwrap()]
                 )
                 .unwrap();
             } else {


### PR DESCRIPTION
This was a bit more involved than I expected as ykrustc gets mutable references in more than one place.

See also https://github.com/softdevteam/ykrustc/pull/181.