### PR TITLE
Tidy and refactor the stopgap interpreter

### DIFF
--- a/untraced/ykcompile/src/arch/x86_64/mod.rs
+++ b/untraced/ykcompile/src/arch/x86_64/mod.rs
@@ -370,13 +370,7 @@ extern "sysv64" fn push_frames_vec(
     let fname =
         unsafe { std::str::from_utf8(std::slice::from_raw_parts(sym_ptr, sym_len)).unwrap() };
     let body = SIR.body(fname).unwrap();
-    let fi = IncomingFrame {
-        body,
-        bbidx,
-        locals,
-    };
-    let v = unsafe { &mut *vptr };
-    v.push(fi);
+    unsafe { &mut *vptr }.push(IncomingFrame::new(body, bbidx, locals));
 }
 
 /// Compile a TIR trace.

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -184,14 +184,12 @@ macro_rules! make_binop {
     };
 }
 
-/// An interpreter stack frame, containing allocated memory for the frames locals, and the function
-/// symbol name and basic block index needed by the interpreter to continue interpreting after
-/// returning from a function call.
+/// An interpreter function frame representing the current state of an executing function.
 #[derive(Debug)]
 struct Frame {
-    /// Allocated memory holding live locals.
+    /// This frame's local variables.
     mem: LocalMem,
-    /// The current basic block index of this frame.
+    /// This frame's program counter (which always increments in terms of basic blocks).
     bbidx: ykpack::BasicBlockIndex,
     /// Body of this stack frame.
     body: Arc<Body>,

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -17,15 +17,27 @@ use ykpack::{
 };
 use yktrace::sir::{RETURN_LOCAL, SIR};
 
-/// Stores information needed to recreate stack frames in the StopgapInterpreter.
+/// When the StopgapInterpreter is called after a guard failure, it is passed a `Vec` of
+/// `IncomingFrame`s from the machine code. These are then converted into other structures more
+/// suitable for interpretation by the StopgapInterpreter.
 pub struct IncomingFrame {
     /// The body of this frame.
-    pub body: Arc<Body>,
+    body: Arc<Body>,
     /// Index of the current basic block we are in. When returning from a function call, the
     /// terminator of this block is were we continue.
-    pub bbidx: usize,
+    bbidx: usize,
     /// Pointer to memory containing the live variables.
-    pub locals: *mut u8,
+    locals: *mut u8,
+}
+
+impl IncomingFrame {
+    pub fn new(body: Arc<Body>, bbidx: usize, locals: *mut u8) -> Self {
+        Self {
+            body,
+            bbidx,
+            locals,
+        }
+    }
 }
 
 /// Heap allocated memory for writing and reading locals of a stack frame.

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -188,7 +188,7 @@ macro_rules! make_binop {
 /// symbol name and basic block index needed by the interpreter to continue interpreting after
 /// returning from a function call.
 #[derive(Debug)]
-struct StackFrame {
+struct Frame {
     /// Allocated memory holding live locals.
     mem: LocalMem,
     /// The current basic block index of this frame.
@@ -203,7 +203,7 @@ struct StackFrame {
 /// over.
 pub struct StopgapInterpreter {
     /// Active stack frames (most recent last).
-    frames: Vec<StackFrame>,
+    frames: Vec<Frame>,
     /// Value to be returned by the interpreter.
     rv: bool,
 }
@@ -231,7 +231,7 @@ impl StopgapInterpreter {
                 offsets: body.offsets().clone(),
                 layout: Layout::from_size_align(layout.0, layout.1).unwrap(),
             };
-            let frame = StackFrame {
+            let frame = Frame {
                 mem,
                 bbidx: u32::try_from(fi.bbidx).unwrap(),
                 body: fi.body.clone(),
@@ -251,9 +251,9 @@ impl StopgapInterpreter {
         sg
     }
 
-    /// Given the symbol name of a function, generate a `StackFrame` which allocates the precise
+    /// Given the symbol name of a function, generate a `Frame` which allocates the precise
     /// amount of memory required by the locals used in that function.
-    fn create_frame(sym: &str) -> StackFrame {
+    fn create_frame(sym: &str) -> Frame {
         let body = SIR.body(&sym).unwrap();
         let (size, align) = body.layout();
         let offsets = body.offsets().clone();
@@ -264,7 +264,7 @@ impl StopgapInterpreter {
             offsets,
             layout,
         };
-        StackFrame {
+        Frame {
             mem,
             bbidx: 0,
             body,

--- a/untraced/yksg/src/lib.rs
+++ b/untraced/yksg/src/lib.rs
@@ -18,7 +18,7 @@ use ykpack::{
 use yktrace::sir::{RETURN_LOCAL, SIR};
 
 /// Stores information needed to recreate stack frames in the StopgapInterpreter.
-pub struct FrameInfo {
+pub struct IncomingFrame {
     /// The body of this frame.
     pub body: Arc<Body>,
     /// Index of the current basic block we are in. When returning from a function call, the
@@ -207,9 +207,9 @@ impl StopgapInterpreter {
         }
     }
 
-    /// Initialise the interpreter from a vector of `FrameInfo`s. Each contains information about
+    /// Initialise the interpreter from a vector of `IncomingFrame`s. Each contains information about
     /// live variables and stack frames, received from a failing guard.
-    pub fn from_frames(v: Vec<FrameInfo>) -> Self {
+    pub fn from_frames(v: Vec<IncomingFrame>) -> Self {
         let mut frames = Vec::new();
         for fi in v.into_iter() {
             let body = &fi.body;


### PR DESCRIPTION
This PR does a fair chunk of mostly-not-very-interesting work to the stopgap interpreter e.g. to make it reflect standard interpreter terminology (https://github.com/softdevteam/yk/commit/15805b0bef0ad1c60b1838d5ea5e6b23dfda84dc) or allocate and clone less memory (https://github.com/softdevteam/yk/commit/6d5157cd8ad4331cd30ff651b4165a09df1dace9). Each commit has, hopefully, adequate motivation attached to it. There's more that could and should be done here, but this feels like enough work to be worth reviewing as-is.

[I tried including a benchmark in https://github.com/softdevteam/yk/commit/dd1f20b8e7496e165a88368c0cf799d472d9951c. I'm not sure if it's measuring what I hoped or not. Either way, it shows no difference before and after this PR, which is a bit disappointing as this PR *should* allocate less memory, but it may be that's an insignificant part of the overall execution time. Profiling and optimising properly are for a future PR.]