### PR TITLE
Start work on the mapper.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Cprefer-dynamic"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+all:
+	${MAKE} -C c_tests test-debug
+	${MAKE} -C c_tests test-release

--- a/c_tests/Makefile
+++ b/c_tests/Makefile
@@ -1,0 +1,29 @@
+LDFLAGS = -Wl,--plugin-opt=-lto-embed-bitcode=optimized -lyktrace
+CFLAGS = -fuse-ld=lld -flto
+
+DEBUG_TARGET_DIR = ../../target/debug
+RELEASE_TARGET_DIR = ../../target/release
+
+# We can't use an rpath for the rust sysroot shared objects as the system rust is found first.
+SYSROOT_LIBDIR = $(shell rustc --print sysroot)/lib
+
+all:
+	@echo "valid targets are:"
+	@echo "  test-release"
+	@echo "  test-debug"
+	exit 1
+
+test-debug:
+	cargo build --features c_testing
+	@for i in `ls -d */`; do \
+		echo "==> Running C test $$i" && ${MAKE} -C $$i \
+		LDFLAGS="${LDFLAGS} -L${DEBUG_TARGET_DIR} -Wl,-rpath=${DEBUG_TARGET_DIR}" \
+		CFLAGS="${CFLAGS}" SYSROOT_LIBDIR=${SYSROOT_LIBDIR}; done
+
+test-release:
+	cargo build --release --features c_testing
+	@for i in `ls -d */`; do \
+		echo "==> Running C test $$i" && ${MAKE} -C $$i \
+		LDFLAGS="${LDFLAGS} -L${RELEASE_TARGET_DIR} -Wl,-rpath=${RELEASE_TARGET_DIR}" \
+		CFLAGS="${CFLAGS}" SYSROOT_LIBDIR=${SYSROOT_LIBDIR}; done
+

--- a/c_tests/blockmap/.gitignore
+++ b/c_tests/blockmap/.gitignore
@@ -1,0 +1,1 @@
+blockmap

--- a/c_tests/blockmap/Makefile
+++ b/c_tests/blockmap/Makefile
@@ -1,0 +1,5 @@
+all: blockmap
+	env LD_LIBRARY_PATH=${SYSROOT_LIBDIR} ./blockmap
+
+blockmap:
+	clang ${CFLAGS} ${LDFLAGS} -o blockmap blockmap.c

--- a/c_tests/blockmap/blockmap.c
+++ b/c_tests/blockmap/blockmap.c
@@ -1,0 +1,19 @@
+// Check the blockmap for this test program contains blocks.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+// FIXME find a way to auto-generate these protos.
+void *yktrace_hwt_mapper_blockmap_new(void);
+size_t yktrace_hwt_mapper_blockmap_len(void *mapper);
+void yktrace_hwt_mapper_blockmap_free(void *mapper);
+
+int
+main(int argc, char **argv)
+{
+    void *bm = yktrace_hwt_mapper_blockmap_new();
+    assert(yktrace_hwt_mapper_blockmap_len(bm) > 0);
+    yktrace_hwt_mapper_blockmap_free(bm);
+    return (EXIT_SUCCESS);
+}

--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["The Yorick Developers"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
 
+[lib]
+crate-type = ["dylib"]
+
 [dependencies]
 num_cpus = "1"
 parking_lot = "0.11"

--- a/yktrace/Cargo.toml
+++ b/yktrace/Cargo.toml
@@ -5,10 +5,17 @@ authors = ["The Yorick Developers"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
 
+[lib]
+crate-type = ["dylib"]
+
 [dependencies]
+byteorder = "1.4.3"
+fxhash = "0.2.1"
 gimli = "0.23.0"
 hwtracer = { git = "https://github.com/softdevteam/hwtracer" }
+leb128 = "0.2.4"
 libc = "0.2.82"
+memmap2 = "0.2.2"
 phdrs = { git = "https://github.com/softdevteam/phdrs" }
 
 [dependencies.object]
@@ -19,3 +26,6 @@ features = ["read_core", "elf"]
 [dev-dependencies]
 fm = "0.2.0"
 regex = "1.4.3"
+
+[features]
+c_testing = []


### PR DESCRIPTION
This change:
 - builds my LLVM fork (required for post-LTO blockmaps).
 - adds an LLVM blockmap parser.
 - tests it from a C program.

The C test infrastructure is rough (for example it isn't run
automatically by cargo and it has no clean target). It may be replaced
by a lang_tester or py.test solution, but this gets us going.

I've had to make a new crate called yktestapi which is responsible for
exposing bits that we want to test from C code (I guess a "ykapi" crate
will follow which exposes only the "real" (non-test) API).

Ideally we'd have had each individual crate export its own interfaces to
C, but this is problematic. ykrt needs to reference yktrace, and any
crate that we want C code to dynamically link needs to be of crate-type
either 'dylib' or 'cdylib', but:

 - Linking >1 "dylib" crate together causes Rust symbol clashing.
   ```
   error: cannot satisfy dependencies so `std` only shows up once
   ```

 - Linking >1 "cdylib" crate toghether causes rust crates to not see
   each other:
   ```
   17 | use yktrace::{CompiledTrace, ThreadTracer};
      |     ^^^^^^^ use of undeclared crate or module `yktrace`
   ```

   I guess the module system can't work between cdylibs, only bare
   function calls via the C ABI.

This of course means that we have to mark more things "public" so that
yktestapi can see them. We can probably live with that.