### PR TITLE
Remove the external notion of an MTThread.

### DIFF
--- a/ykrt/Cargo.toml
+++ b/ykrt/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 num_cpus = "1"
+once_cell = "1"
 parking_lot = "0.11"
 parking_lot_core = "0.8"
 strum = { version = "0.20", features = ["derive"] }

--- a/ykrt/src/lib.rs
+++ b/ykrt/src/lib.rs
@@ -6,4 +6,4 @@ mod location;
 pub(crate) mod mt;
 
 pub use self::location::Location;
-pub use self::mt::{MTBuilder, MT};
+pub use self::mt::MT;


### PR DESCRIPTION
Before this commit we required users to create threads through the MT struct, so that we could pass those threads an `MTThread` structure. This works well if you know from the very beginning that you're creating a yk interpreter, but will not work if you e.g. embed a yk regex interpreter inside a wider program that's otherwise ignorant about yk (and may create threads via another API).

The "obvious" solution is to make `MTThread` a thread_local, but if we do that, we also have to make MT a global. And that's more-or-less what this commit does, with the minor tweak that it hides `MTThread` from the outside world.

Users can access the MT struct via `MT::global()` at any point in their program: `MTThread` is a thread local that is used by `MT` internally but doesn't need to be exposed to the user.

This makes the API simpler to use, perhaps slightly icky in some ways (we've all been brought up to believe that globals are bad!), but probably powerful enough to carry us for a decent distance with, hopefully, only minor tweaks.

Internally, this clearly needs work: `MT`s are initialised eagerly but `MTThread`s lazily; and the horrible `with` hack needed to get an `MTThread` reference to `hot_location` is best not mentioned in polite company. Those can, I believe, be finessed in future PRs without changing the external API. Put another way: this commit is as close to "minimal change" as I think I can get.