### PR TITLE
Add a thin wrapper around LLVMSymbolizer.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -37,14 +37,14 @@ git clone -b yk/12.0-2021-04-15 https://github.com/vext01/llvm-project
 cd llvm-project
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
     -DLLVM_INSTALL_UTILS=On \
     -DCMAKE_BUILD_TYPE=release \
     -DLLVM_ENABLE_ASSERTIONS=On \
     -DLLVM_ENABLE_PROJECTS="lld;clang" \
     ../llvm
 make -j `nproc` install
-export PATH=`pwd`/inst/bin:${PATH}
+export PATH=`pwd`/../inst/bin:${PATH}
 cd ../../..
 
 cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "c_tests",
+    "ykllvmwrap",
     "ykrt",
     "yktrace",
 ]

--- a/ykllvmwrap/Cargo.toml
+++ b/ykllvmwrap/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ykllvmwrap"
+version = "0.1.0"
+authors = ["The Yorick Developers"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+cc = "1.0.67"
+libc = "0.2.94"
+
+[build-dependencies]
+cc = "1.0.67"

--- a/ykllvmwrap/build.rs
+++ b/ykllvmwrap/build.rs
@@ -1,0 +1,45 @@
+use std::process::Command;
+
+fn main() {
+    // Compile our wrappers with the right LLVM C++ flags.
+    let cxxflags_out = Command::new("llvm-config")
+        .arg("--cxxflags")
+        .output()
+        .unwrap()
+        .stdout;
+    let cxxflags_str = std::str::from_utf8(&cxxflags_out).unwrap();
+    let cxxflags = cxxflags_str.split_whitespace().collect::<Vec<_>>();
+
+    let mut comp = cc::Build::new();
+    for cf in cxxflags {
+        comp.flag(cf);
+    }
+    comp.file("src/ykllvmwrap.cc")
+        .compiler("clang++")
+        // Lots of unused parameters in the LLVM headers.
+        .flag("-Wno-unused-parameter")
+        .cpp(true);
+    comp.compile("ykllvmwrap");
+
+    // Ensure that downstream crates performing linkage use the right -L and -l flags.
+    let lib_dir = Command::new("llvm-config")
+        .arg("--libdir")
+        .output()
+        .unwrap()
+        .stdout;
+    let lib_dir = std::str::from_utf8(&lib_dir).unwrap();
+    println!("cargo:rustc-link-search={}", lib_dir);
+
+    let libs = Command::new("llvm-config")
+        .arg("--libs")
+        .output()
+        .unwrap()
+        .stdout;
+    let libs = std::str::from_utf8(&libs).unwrap();
+    for lib in libs.split_whitespace() {
+        assert!(lib.starts_with("-l"));
+        println!("cargo:rustc-link-lib={}", &lib[2..]);
+    }
+    println!("cargo:rustc-link-lib=tinfo");
+    println!("cargo:rustc-link-lib=z");
+}

--- a/ykllvmwrap/src/lib.rs
+++ b/ykllvmwrap/src/lib.rs
@@ -1,0 +1,3 @@
+// Exporting parts of the LLVM C++ API not present in the LLVM C API.
+
+pub mod symbolizer;

--- a/ykllvmwrap/src/symbolizer.rs
+++ b/ykllvmwrap/src/symbolizer.rs
@@ -1,0 +1,97 @@
+//! A wrapper around llvm::symbolizer::LLVMSymbolizer.
+
+use libc::free;
+use std::{
+    ffi::{c_void, CStr},
+    ops::Drop,
+    os::raw::c_char,
+};
+
+extern "C" {
+    fn __yk_symbolizer_new() -> *mut c_void;
+    fn __yk_symbolizer_free(symbolizer: *mut c_void);
+    fn __yk_symbolizer_find_code_sym(symbolizer: *mut c_void, addr: usize) -> *mut c_char;
+}
+
+pub struct Symbolizer(*mut c_void);
+
+impl Symbolizer {
+    pub fn new() -> Self {
+        Self(unsafe { __yk_symbolizer_new() })
+    }
+
+    /// Returns the name of the symbol at the provided virtual address.
+    pub fn find_code_sym(&self, vaddr: usize) -> Option<String> {
+        let ptr = unsafe { __yk_symbolizer_find_code_sym(self.0, vaddr) };
+        if ptr.is_null() {
+            None
+        } else {
+            let ret = {
+                let sym = unsafe { CStr::from_ptr(ptr) };
+                String::from(sym.to_str().unwrap())
+            };
+            unsafe { free(ptr as *mut _) };
+            Some(ret)
+        }
+    }
+}
+
+impl Drop for Symbolizer {
+    fn drop(&mut self) {
+        unsafe { __yk_symbolizer_free(self.0) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Symbolizer;
+
+    extern "C" {
+        fn getuid();
+    }
+
+    #[inline(never)]
+    fn symbolize_me_mangled() {}
+
+    // This function has a different signature to the one above to prevent LLVM from merging the
+    // functions (and their symbols) when optimising in --release mode.
+    #[inline(never)]
+    #[no_mangle]
+    fn symbolize_me_unmangled() -> u8 {
+        1
+    }
+
+    #[test]
+    fn find_code_sym_mangled() {
+        let f_addr = symbolize_me_mangled as *const fn() as *const _ as usize;
+        let s = Symbolizer::new();
+        let sym = s.find_code_sym(f_addr).unwrap();
+        // The symbol will be suffixed with an auto-generated module name, e.g.:
+        // ykllvmwrap::symbolizer::tests::symbolize_me_mangled::hc7a76ddceae6f9c4
+        assert!(sym.starts_with("ykllvmwrap::symbolizer::tests::symbolize_me_mangled::"));
+        let elems = sym.split("::");
+        assert_eq!(elems.count(), 5);
+    }
+
+    #[test]
+    fn find_code_sym_unmangled() {
+        let f_addr = symbolize_me_unmangled as *const fn() as *const _ as usize;
+        let s = Symbolizer::new();
+        let sym = s.find_code_sym(f_addr).unwrap();
+        assert_eq!(sym, "symbolize_me_unmangled");
+    }
+
+    #[test]
+    fn find_code_sym_libc() {
+        let f_addr = getuid as *const fn() as *const _ as usize;
+        let s = Symbolizer::new();
+        let sym = s.find_code_sym(f_addr).unwrap();
+        assert_eq!(sym, "getuid");
+    }
+
+    #[test]
+    fn find_code_sym_not_found() {
+        // Virtual address 0x1 is obviously nonsense.
+        assert!(Symbolizer::new().find_code_sym(1).is_none());
+    }
+}

--- a/ykllvmwrap/src/ykllvmwrap.cc
+++ b/ykllvmwrap/src/ykllvmwrap.cc
@@ -1,0 +1,46 @@
+// LLVM-related C++ code wrapped in the C ABI for calling from Rust.
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <dlfcn.h>
+#include <llvm/DebugInfo/Symbolize/Symbolize.h>
+#include <string.h>
+
+using namespace llvm;
+using namespace llvm::symbolize;
+
+extern "C" LLVMSymbolizer *__yk_symbolizer_new() {
+    return new LLVMSymbolizer;
+}
+
+extern "C" void __yk_symbolizer_free(LLVMSymbolizer *Symbolizer) {
+    delete Symbolizer;
+}
+
+// Finds the name of a code symbol from a virtual address.
+// The caller is responsible for freeing the returned (heap-allocated) C string.
+extern "C" char *__yk_symbolizer_find_code_sym(LLVMSymbolizer *Symbolizer, void *Vaddr) {
+    // Find which of the loaded objects holds this virtual address.
+    Dl_info Info;
+    if (dladdr(Vaddr, &Info) == 0 ) {
+        return NULL;
+    }
+
+    // Find the corresponding offset of vaddr from the start of the object.
+    auto Offs = (uintptr_t) Vaddr - (uintptr_t) Info.dli_fbase;
+
+    // Use the LLVM symbolizer to find the symbol name. Note that we don't
+    // simply rely on `Info.dli_sname`, as `dl_addr()` can only find a subset
+    // of symbols -- those exported -- and we don't want users to have to link
+    // with --export-dynamic.
+    auto LineInfo = Symbolizer->symbolizeCode(Info.dli_fname,
+        {Offs, object::SectionedAddress::UndefSection});
+    if (auto err = LineInfo.takeError()) {
+        return NULL;
+    }
+
+    // OPTIMISE_ME: get rid of heap allocation.
+    return strdup(LineInfo->FunctionName.c_str());
+}


### PR DESCRIPTION
This allows us to do virtual addresses to symbol name mappings, which is fundamental to mapping PT block addresses to LLVM IR blocks.

This requires calling to C++, so I've added a `ykllvm` crate to contain
LLVM C++ wrappers. I'm sure this won't be the last.

[I notice that in the meantime @ltratt has bagsied the name `ykllvm` for a possible llvm fork, so perhaps we want to rename the new crate for C++ LLVM wrappers here? `ykcpp` or `ykll`?]