### PR TITLE
Tweak ykrt's C API a little bit.

### DIFF
--- a/c_tests/tests/basic_mt.c
+++ b/c_tests/tests/basic_mt.c
@@ -7,10 +7,10 @@ int
 main(int argc, char **argv)
 {
     MT *mt = yk_mt();
-    Location loc = yk_new_location();
+    YkLocation loc = yk_location_new();
     for (int i = 0; i < yk_mt_hot_threshold(mt); i++) {
         yk_control_point(mt, &loc);
     }
-    yk_drop_location(&loc);
+    yk_location_drop(loc);
     return 0;
 }

--- a/ykcapi/src/lib.rs
+++ b/ykcapi/src/lib.rs
@@ -29,12 +29,12 @@ pub extern "C" fn yk_control_point(mt: *mut MT, loc: *mut Location) {
 }
 
 #[no_mangle]
-pub extern "C" fn yk_new_location() -> Location {
+pub extern "C" fn yk_location_new() -> Location {
     Location::new()
 }
 
 #[no_mangle]
-pub extern "C" fn yk_drop_location(loc: *mut Location) {
+pub extern "C" fn yk_location_drop(loc: Location) {
     drop(loc)
 }
 

--- a/ykcapi/yk.h
+++ b/ykcapi/yk.h
@@ -1,3 +1,6 @@
+#ifndef YK_H
+#define YK_H
+
 #include <stdint.h>
 
 /// A meta-tracer.
@@ -19,10 +22,10 @@ typedef struct MT MT;
 // control points).
 typedef struct {
     uintptr_t state;
-} Location;
+} YkLocation;
 
 #if defined(__x86_64)
-typedef uint32_t HotThreshold;
+typedef uint32_t YkHotThreshold;
 #else
 #error Unable to determine type of HotThreshold
 #endif
@@ -30,26 +33,28 @@ typedef uint32_t HotThreshold;
 // Return a reference to the global `MT` instance: at any point, there is at
 // most one of these per process and an instance will be created if it does not
 // already exist.
-MT *yk_mt();
+MT *yk_mt(void);
 
 // Return this `MT` instance's current hot threshold. Notice that this value
 // can be changed by other threads and is thus potentially stale as soon as it
 // is read.
-HotThreshold yk_mt_hot_threshold(MT *);
+YkHotThreshold yk_mt_hot_threshold(MT *);
 
 // Attempt to execute a compiled trace for location `loc`. `NULL` may be passed
 // to `loc` to indicate that this particular point in the user's program cannot
 // ever be the beginning of a trace.
-void yk_control_point(MT *, Location *);
+void yk_control_point(MT *, YkLocation *);
 
 // Create a new `Location`.
 //
 // Note that a `Location` created by this call must not simply be discarded: if
 // no longer wanted, it must be passed to `yk_drop_location` to allow
 // appropriate clean-up.
-Location yk_new_location();
+YkLocation yk_location_new(void);
 
 // Clean-up a `Location` previously created by `yk_new_location`. The
 // `Location` must not be further used after this call or undefined behaviour
 // will occur.
-void yk_drop_location(Location *);
+void yk_location_drop(YkLocation);
+
+#endif


### PR DESCRIPTION
There is one non-cosmetic change:

  * We now pass a YkLocation (not a *YkLocation) to `drop` to make a slight parallel with a Rust "move" (i.e. trying to be a bit clearer that "after this call, you can't do anything with this location").

Then two cosmetic changes:

  * Adding Yk prefixes.
  * Adding a "don't include this header multiple times" #define.